### PR TITLE
Add record on-chain method

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -70,11 +70,11 @@
         },
         "factom-api": {
             "hashes": [
-                "sha256:50f6292d83394b7bfe090e8abae4b911778d1357a30256d12b4419f7eeb0368e",
-                "sha256:f6c151db2f1a0e4bc78e2f57c1b672a05b8de75e6756b86d2a38f4db4f4e06c9"
+                "sha256:12729281b9b0549e0ea365dc94340f7ca10cd70853d960109bd8006d5d08c5a0",
+                "sha256:680c702fe109f7bfeb7c59f4d4a69c02c591fc81b82976a75dcaef6295dc89ff"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         },
         "idna": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ The library enables:
 * exporting public metadata to be recorded on Factom
 * encrypting the newly created keys
 
-You can find an example of the library workflow in the `examples/` directory.
+You can find an example of the library workflow in the `examples/` directory. In order to run the
+example, please note that it is necessary to create an environment variable called `EC_ADDR`, which
+contains a funded EC address to pay the fees for recording the DID on-chain.
 
 ## Build
 

--- a/did/did.py
+++ b/did/did.py
@@ -5,6 +5,8 @@ import json
 import os
 import re
 
+from factom.exceptions import FactomAPIError
+
 from did.encryptor import encrypt_keys
 from did.enums import SignatureType, EntryType, PurposeType
 from did.keys import generate_key_pair
@@ -193,6 +195,41 @@ class DID:
             },
             'did': self.id
         })
+
+    def record_on_chain(self, factomd, walletd, ec_address, verbose=False):
+        """
+        Attempts to record the DID document on-chain.
+
+        Parameters
+        ----------
+        factomd: obj
+            Factomd instance, instantiated from the Python factom-api package.
+        walletd: obj
+            Factom walletd instance, instantiated from the Python factom-api package.
+        ec_address: str
+            EC address used to pay for the chain & entry creation.
+        verbose: bool (optional)
+            If true, display the contents of the entry that will be recorded
+            on-chain. Default is False.
+
+        Raises
+        ------
+            RuntimeException
+                - If the chain cannot be created
+        """
+
+        from pprint import pprint
+
+        entry_data = self.export_entry_data()
+        if verbose:
+            pprint(entry_data)
+
+        try:
+            walletd.new_chain(factomd, entry_data['ext_ids'], entry_data['content'],
+                              ec_address=ec_address)
+        except FactomAPIError as e:
+            raise RuntimeException(
+                'Failed while trying to record DID data on-chain: {}'.format(e.data))
 
     def _get_did_document(self):
         """

--- a/did/did.py
+++ b/did/did.py
@@ -224,9 +224,12 @@ class DID:
         if verbose:
             pprint(entry_data)
 
+        # Encode the entry data
+        ext_ids = map(lambda x: x.encode('utf-8'), entry_data['ext_ids'])
+        content = entry_data['content'].encode('utf-8')
+
         try:
-            walletd.new_chain(factomd, entry_data['ext_ids'], entry_data['content'],
-                              ec_address=ec_address)
+            walletd.new_chain(factomd, ext_ids, content, ec_address=ec_address)
         except FactomAPIError as e:
             raise RuntimeError(
                 'Failed while trying to record DID data on-chain: {}'.format(e.data))

--- a/did/did.py
+++ b/did/did.py
@@ -214,7 +214,7 @@ class DID:
 
         Raises
         ------
-            RuntimeException
+            RuntimeError
                 - If the chain cannot be created
         """
 
@@ -228,7 +228,7 @@ class DID:
             walletd.new_chain(factomd, entry_data['ext_ids'], entry_data['content'],
                               ec_address=ec_address)
         except FactomAPIError as e:
-            raise RuntimeException(
+            raise RuntimeError(
                 'Failed while trying to record DID data on-chain: {}'.format(e.data))
 
     def _get_did_document(self):

--- a/examples/example.py
+++ b/examples/example.py
@@ -8,11 +8,11 @@ from did.encryptor import decrypt_keys_from_str, decrypt_keys_from_json_str, \
     decrypt_keys_from_json_file
 
 
+# NOTE: You must set an EC_ADDR environment variable, which points to a funded
+# EC address, in order to be able to record DIDs on-chain
 factomd = Factomd()
 walletd = FactomWalletd()
-fct_address = 'FA2jK2HcLnRdS94dEcU27rF3meoJfpUcZPSinpb7AwQvPRY6RL1Q'
-# ec_address = 'EC3VjuH17eACyP22WwxPcqcbnVkE8QSd1HJP7MXDJkgR3hvaPBhP'
-ec_address = 'EC3AZkzRPvw4wsHwjSgqkegK3Q9tUDndP1n4koQvvD6PATu7VXmv'
+ec_address = os.environ.get('EC_ADDR')
 
 
 def create_new_did():

--- a/examples/example.py
+++ b/examples/example.py
@@ -11,7 +11,8 @@ from did.encryptor import decrypt_keys_from_str, decrypt_keys_from_json_str, \
 factomd = Factomd()
 walletd = FactomWalletd()
 fct_address = 'FA2jK2HcLnRdS94dEcU27rF3meoJfpUcZPSinpb7AwQvPRY6RL1Q'
-ec_address = 'EC3VjuH17eACyP22WwxPcqcbnVkE8QSd1HJP7MXDJkgR3hvaPBhP'
+# ec_address = 'EC3VjuH17eACyP22WwxPcqcbnVkE8QSd1HJP7MXDJkgR3hvaPBhP'
+ec_address = 'EC3AZkzRPvw4wsHwjSgqkegK3Q9tUDndP1n4koQvvD6PATu7VXmv'
 
 
 def create_new_did():
@@ -105,6 +106,4 @@ def decrypt_keys_from_file():
 
 
 if __name__ == '__main__':
-    # did_object = create_new_did()
-    # pprint(did_object.export_entry_data())
     record_did_on_chain()

--- a/examples/example.py
+++ b/examples/example.py
@@ -61,9 +61,8 @@ def create_new_did():
 
 def record_did_on_chain():
     new_did = create_new_did()
-    entry_data = new_did.export_entry_data()
-    walletd.new_chain(factomd, entry_data['ext_ids'], entry_data['content'], ec_address=ec_address)
-    pprint(entry_data)
+    # Show the data to be recorded for illustration purposes
+    new_did.record_on_chain(factomd, walletd, ec_address, verbose=True)
 
 
 def encrypt_keys_as_str_and_decrypt():
@@ -106,5 +105,6 @@ def decrypt_keys_from_file():
 
 
 if __name__ == '__main__':
-    did_object = create_new_did()
-    pprint(did_object.export_entry_data())
+    # did_object = create_new_did()
+    # pprint(did_object.export_entry_data())
+    record_did_on_chain()


### PR DESCRIPTION
This PR:
* updates the factom-api dependency to version 1.0.1
* adds a convenience `record_on_chain` method to the DID object
* updates the example to use an environment variable for specifying an EC address