### PR TITLE
Add code formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 black = "*"
+pre-commit = "*"
 
 [packages]
 pycryptodome = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pytest = "*"
+black = "*"
 
 [packages]
 pycryptodome = "*"
@@ -11,7 +13,9 @@ base58 = "*"
 ecdsa = "*"
 ed25519 = "*"
 factom-api = "*"
-pytest = "*"
 
 [requires]
 python_version = "3.7"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5858eddb98996e7e43ddad12b51d7752325883d48e5acbfb4856a47238e9663c"
+            "sha256": "d96a19836ec8bcb8ca6bff2792f71cb0dbe55638cc483faba180a99b8a2c34ff"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -126,6 +126,13 @@
             ],
             "version": "==1.4.3"
         },
+        "aspy.yaml": {
+            "hashes": [
+                "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc",
+                "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"
+            ],
+            "version": "==1.3.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
@@ -148,12 +155,26 @@
             "index": "pypi",
             "version": "==19.3b0"
         },
+        "cfgv": {
+            "hashes": [
+                "sha256:edb387943b665bf9c434f717bf630fa78aecd53d5900d2e05da6ad6048553144",
+                "sha256:fbd93c9ab0a523bf7daec408f3be2ed99a980e20b2d19b50fc184ca6b820d289"
+            ],
+            "version": "==2.0.1"
+        },
         "click": {
             "hashes": [
                 "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:4f1fe9a59df4e80fcb0213086fcf502bc1765a01ea4fe8be48da3b65afd2a017",
+                "sha256:d8919589bd2a5f99c66302fec0ef9027b12ae150b0b0213999ad3f695fc7296e"
+            ],
+            "version": "==1.4.7"
         },
         "importlib-metadata": {
             "hashes": [
@@ -170,6 +191,12 @@
             ],
             "version": "==7.2.0"
         },
+        "nodeenv": {
+            "hashes": [
+                "sha256:ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a"
+            ],
+            "version": "==1.3.3"
+        },
         "packaging": {
             "hashes": [
                 "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
@@ -183,6 +210,14 @@
                 "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
             "version": "==0.12.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:1d3c0587bda7c4e537a46c27f2c84aa006acc18facf9970bf947df596ce91f3f",
+                "sha256:fa78ff96e8e9ac94c748388597693f18b041a181c94a4f039ad20f45287ba44a"
+            ],
+            "index": "pypi",
+            "version": "==1.18.3"
         },
         "py": {
             "hashes": [
@@ -206,6 +241,24 @@
             "index": "pypi",
             "version": "==5.1.2"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+            ],
+            "version": "==5.1.2"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
@@ -219,6 +272,13 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:680af46846662bb38c5504b78bad9ed9e4f3ba2d54f54ba42494fdf94337fe30",
+                "sha256:f78d81b62d3147396ac33fc9d77579ddc42cc2a98dd9ea38886f616b33bc7fb2"
+            ],
+            "version": "==16.7.5"
         },
         "wcwidth": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e8392f81faa7400384946e6f65a31a8415fd31d0144a428dc636279f3dc7385a"
+            "sha256": "5858eddb98996e7e43ddad12b51d7752325883d48e5acbfb4856a47238e9663c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,20 +16,6 @@
         ]
     },
     "default": {
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "version": "==1.3.0"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
-            ],
-            "version": "==19.1.0"
-        },
         "base58": {
             "hashes": [
                 "sha256:1e42993c0628ed4f898c03b522b26af78fb05115732549b21a028bc4633d19ab",
@@ -70,11 +56,11 @@
         },
         "factom-api": {
             "hashes": [
-                "sha256:12729281b9b0549e0ea365dc94340f7ca10cd70853d960109bd8006d5d08c5a0",
-                "sha256:680c702fe109f7bfeb7c59f4d4a69c02c591fc81b82976a75dcaef6295dc89ff"
+                "sha256:54f1ff0e065af0b6ccc87c56fd0dd8a71bc6691a58cefcf318e9c35bd250120a",
+                "sha256:8c4a7891e1eba5b016894922402e28107283c9938e5e6a365da47b04b419f219"
             ],
             "index": "pypi",
-            "version": "==1.0.1"
+            "version": "==1.0.2"
         },
         "idna": {
             "hashes": [
@@ -83,12 +69,99 @@
             ],
             "version": "==2.8"
         },
+        "pycryptodome": {
+            "hashes": [
+                "sha256:023c294367d7189ae224fb61bc8d49a2347704087c1c78dbd5ab114dd5b97761",
+                "sha256:0f29e1238ad3b6b6e2acd7ea1d8e8b382978a56503f2c48b67d5dc144d143cb0",
+                "sha256:18f376698e3ddcb1d3b312512ca78c9eed132e68ac6d0bf2e72452dfe213e96f",
+                "sha256:1de815b847982f909dc2e5e2ca641b85cde80d95cc7e6a359c03d4b42cd21568",
+                "sha256:1ff619b8e4050799ca5ca0ffdf8eb0dbccba6997997866755f37e6aa7dde23fe",
+                "sha256:233a04bb7bdd4b07e14d61d5166150942d872802daa4f049d49a453fe0659e94",
+                "sha256:33c07e1e36ec84524b49f99f11804d5e4d2188c643e84d914cb1e0a277ed3c79",
+                "sha256:3701822a085dbebf678bfbdfbd6ebd92ffa80d5a544c9979984bf16a67c9790b",
+                "sha256:3f8e6851c0a45429f9b86c1597d3b831b0cff140b3e170a891fce55ef8dac2bb",
+                "sha256:4f6cdddf1fe72e7f173e9734aa19b94cbd046b61a8559d650ff222e36021d5c1",
+                "sha256:52d20b22c5b1fc952b4c686b99a6c55c3b0b0a673bec30570f156a72198f66ff",
+                "sha256:5452b534fecf8bf57cf9106d00877f5f4ab7264e7a5e1f5ea8d15b04517d1255",
+                "sha256:5a7a9a4a7f8f0990fa97fee71c7f7e0c412925c515cfc6d4996961e92c9be8e5",
+                "sha256:600bf9dd5fbed0feee83950e2a8baacaa1f38b56c237fff270d31e47f8da9e52",
+                "sha256:6840c9881e528224ebf72b3f73b3d11baf399e265106c9f4d9bae4f09615a93a",
+                "sha256:71b041d43fe13004abc36ca720ac64ea489ee8a3407a25116481d0faf9d62494",
+                "sha256:7252498b427c421e306473ed344e58235eedd95c15fec2e1b33d333aefa1ea10",
+                "sha256:8d2135c941d38f241e0e62dbdfc1ca5d9240527e61316126797f50b6f3e49825",
+                "sha256:a0962aea03933b99cf391c3e10dfef32f77915d5553464264cfbc6711f31d254",
+                "sha256:a117047a220b3911d425affcd1cbc97a1af7ea7eb5d985d9964d42b4f0558489",
+                "sha256:a35a5c588248ba00eb976a8554211e584a55de286783bc69b12bdd7954052b4a",
+                "sha256:c1a4f3f651471b9bf60b0d98fa8a994b8a73ff8ab4edc691e23243c853aaff9f",
+                "sha256:c419943306756ddd1a1997120bb073733bc223365909c68185106d5521cbc0ef",
+                "sha256:c453ad968b67d66448543420ec39770c30bd16d986058255f058ab87c4f6cc1f",
+                "sha256:d2d78644655629c7d1b9bf28e479d29facc0949d9ff095103ca9c2314b329ee0",
+                "sha256:d7be60dc2126ee350ac7191549f5ab05c2dd76a5d5a3022249f395a401c6ea37",
+                "sha256:dbeb08ad850056747aa7d5f33273b7ce0b9a77910604a1be7b7a6f2ef076213f",
+                "sha256:f02382dc1bf91fb7123f2a3851fb1b526c871fa9359f387f2bcc847efc74ae52"
+            ],
+            "index": "pypi",
+            "version": "==3.9.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "version": "==2.22.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "version": "==1.25.3"
+        }
+    },
+    "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
+                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
+            ],
+            "index": "pypi",
+            "version": "==19.3b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
         "importlib-metadata": {
             "hashes": [
-                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
-                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
+                "sha256:9ff1b1c5a354142de080b8a4e9803e5d0d59283c93aed808617c787d16768375",
+                "sha256:b7143592e374e50584564794fcb8aaf00a23025f9db866627f89a21491847a8d"
             ],
-            "version": "==0.19"
+            "markers": "python_version < '3.8'",
+            "version": "==0.20"
         },
         "more-itertools": {
             "hashes": [
@@ -118,40 +191,6 @@
             ],
             "version": "==1.8.0"
         },
-        "pycryptodome": {
-            "hashes": [
-                "sha256:0281dc6a65a4d0d9e439f54e0ad5faf27bfdc2ebe9ead36912bac74a0920fa2e",
-                "sha256:02af9b284f5c9a55f06f5e4532c16c9b7bd958e293e93969934d864ef7bd87ee",
-                "sha256:09da99372fb69762e4b9690291176a166cc351793e2e1c9405d29ca291503aa8",
-                "sha256:0c2400ccfc049c3f24e65d4f02bb4208d86e408011019e455fab7f50d2b226c9",
-                "sha256:2081dd6dce6b21bf3596427edaedd4f2561dce616893b162ed2c674f3a3ca70a",
-                "sha256:28b86ec9fdb005a2a18e4862a3a7277046738825ee8dc89cda5657e75a396089",
-                "sha256:2d790c0d4c0d5edcf5fbab4e2af7b03757e40c5ae8d217f0dfe9ddea37fe130f",
-                "sha256:2f24906153dca16528cf5515b1afa9ef635423d5a654904e861765f88ca667b6",
-                "sha256:30d283939896fa4bacbdb9fa86e6fd51e9a5b953a511e210b38481f697f289f5",
-                "sha256:31f78b67f97830d137f74813c0502a181a03b43a32ed124049bb20428176c307",
-                "sha256:33c1f3a380fd38ab4dd4372bef17e98002b360b52814bb1b077693b1bd06ec87",
-                "sha256:34091e9a6650c44e25339f22fc821396f19f152f65be2546edd823a093fb5a04",
-                "sha256:567fb73951ab6865a2eb1a0060b54be1e27302574f6c65879525bdf53fab49e1",
-                "sha256:5bc40f8aa7ba8ca7f833ad2477b9d84e1bfd2630b22a46d9bbd221982f8c3ac0",
-                "sha256:6b0a0ccf33c7a6100c569667c888335a4aaf0d22218cb97b4963a65d70f6c343",
-                "sha256:71b93157f1ce93fc7cfff9359b76def2b4826a7ef7a7f95e070161368e7f584a",
-                "sha256:7d939d511b7dac29b2d936706786771ecb8256e43fade5cdb0e8bc58f02b86cf",
-                "sha256:7fbc5a93d52e4c51487f4648b00dc41700adb144d10fc567b05f852e76c243ad",
-                "sha256:9cb94b8f9c915a5d2b273d612a25a8e5d67b49543f8eb6bcec0275ac46cda421",
-                "sha256:a585ea1722f9731e75881d5ffcc51d11c794d244ac57e7c2a9cbb8d5ac729302",
-                "sha256:a6458dd7a10ae51f6fce56bdfc79bf6d3b54556237045d09e77fbda9d6d37864",
-                "sha256:a9fb92e948128bce0239b87c6efcf2cb1c5a703d0b41dd6835211e6fafd1c5df",
-                "sha256:b0b6b4ca1c53e7d6ca9f2720919f63837f05e7a5f92912a2bc29bfd03ed3b54f",
-                "sha256:b7d22c8d648aaa3a7ec785eda544402141eb78ac5ffbba4cbe2c3a1f52276870",
-                "sha256:bc9560574a868cfa2ba781b7bb0b4685b08ea251697abfc49070ffc05e1cbee6",
-                "sha256:c0c5a576f3f7b7de3f86889cb47eb51b59dc11db9cf1e2a0f51eb4d988010ea4",
-                "sha256:e1c91c2fa942a71c98a7a1f462de6dbbe82f34b9267eb8131314d97bd13bf0d4",
-                "sha256:ec936361ad78aa95382c313df95777795b8185aac5dd3ec5463363ea94b556fc"
-            ],
-            "index": "pypi",
-            "version": "==3.8.2"
-        },
         "pyparsing": {
             "hashes": [
                 "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
@@ -161,18 +200,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d",
-                "sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77"
+                "sha256:95d13143cc14174ca1a01ec68e84d76ba5d9d493ac02716fd9706c949a505210",
+                "sha256:b78fe2881323bd44fd9bd76e5317173d4316577e7b1cddebae9136a4495ec865"
             ],
             "index": "pypi",
-            "version": "==5.0.1"
-        },
-        "requests": {
-            "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
-            ],
-            "version": "==2.22.0"
+            "version": "==5.1.2"
         },
         "six": {
             "hashes": [
@@ -181,12 +213,12 @@
             ],
             "version": "==1.12.0"
         },
-        "urllib3": {
+        "toml": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
-            "version": "==1.25.3"
+            "version": "==0.10.0"
         },
         "wcwidth": {
             "hashes": [
@@ -197,11 +229,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
-    },
-    "develop": {}
+    }
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ contains a funded EC address to pay the fees for recording the DID on-chain.
 	pipenv install
 ```
 
+or
+```
+    pipenv install --pre -d
+```
+to install both the default and development dependencies
+
 * Activate the virtual environment:
 ```
 	pipenv shell

--- a/did/enums.py
+++ b/did/enums.py
@@ -1,19 +1,19 @@
 from enum import Enum
 
-__all__ = ['SignatureType', 'EntryType', 'PurposeType']
+__all__ = ["SignatureType", "EntryType", "PurposeType"]
 
 
 class SignatureType(Enum):
-    EdDSA = 'Ed25519'
-    ECDSA = 'ECDSASecp256k1'
-    RSA = 'RSA'
+    EdDSA = "Ed25519"
+    ECDSA = "ECDSASecp256k1"
+    RSA = "RSA"
 
 
 class EntryType(Enum):
-    Create = 'DIDManagement'
-    Update = 'DIDUpdate'
+    Create = "DIDManagement"
+    Update = "DIDUpdate"
 
 
 class PurposeType(Enum):
-    PublicKey = 'publicKey'
-    AuthenticationKey = 'authentication'
+    PublicKey = "publicKey"
+    AuthenticationKey = "authentication"

--- a/did/keys.py
+++ b/did/keys.py
@@ -6,7 +6,7 @@ import ed25519
 from did.enums import SignatureType
 from did.models import KeyPairModel
 
-__all__ = ['generate_key_pair']
+__all__ = ["generate_key_pair"]
 
 
 def generate_key_pair(signature_type):
@@ -36,19 +36,25 @@ def generate_key_pair(signature_type):
     elif signature_type == SignatureType.RSA.value:
         return _generate_rsa_key_pair()
     else:
-        raise RuntimeError('Invalid signature type.')
+        raise RuntimeError("Invalid signature type.")
 
 
 def _generate_ed_dsa_key_pair():
     signing_key, verifying_key = ed25519.create_keypair()
-    key_pair = KeyPairModel(base58.b58encode(verifying_key.to_bytes()), base58.b58encode(signing_key.to_bytes()))
+    key_pair = KeyPairModel(
+        base58.b58encode(verifying_key.to_bytes()),
+        base58.b58encode(signing_key.to_bytes()),
+    )
     return key_pair
 
 
 def _generate_ec_dsa_key_pair():
     signing_key = SigningKey.generate(curve=SECP256k1)
     verifying_key = signing_key.get_verifying_key()
-    key_pair = KeyPairModel(base58.b58encode(verifying_key.to_string()), base58.b58encode(signing_key.to_string()))
+    key_pair = KeyPairModel(
+        base58.b58encode(verifying_key.to_string()),
+        base58.b58encode(signing_key.to_string()),
+    )
     return key_pair
 
 

--- a/did/models.py
+++ b/did/models.py
@@ -1,13 +1,35 @@
 from collections import namedtuple
 
-__all__ = ['KeyPairModel', 'ManagementKeyModel', 'DidKeyModel', 'ServiceModel']
+__all__ = ["KeyPairModel", "ManagementKeyModel", "DidKeyModel", "ServiceModel"]
 
-KeyPairModel = namedtuple('KeyPairModel', ('public_key', 'private_key'))
+KeyPairModel = namedtuple("KeyPairModel", ("public_key", "private_key"))
 
-ManagementKeyModel = namedtuple('ManagementKeyModel', ('alias', 'priority', 'signature_type', 'controller',
-                                                       'public_key', 'private_key', 'priority_requirement'))
+ManagementKeyModel = namedtuple(
+    "ManagementKeyModel",
+    (
+        "alias",
+        "priority",
+        "signature_type",
+        "controller",
+        "public_key",
+        "private_key",
+        "priority_requirement",
+    ),
+)
 
-DidKeyModel = namedtuple('DidKeyModel', ('alias', 'purpose', 'signature_type', 'controller', 'public_key',
-                                         'private_key', 'priority_requirement'))
+DidKeyModel = namedtuple(
+    "DidKeyModel",
+    (
+        "alias",
+        "purpose",
+        "signature_type",
+        "controller",
+        "public_key",
+        "private_key",
+        "priority_requirement",
+    ),
+)
 
-ServiceModel = namedtuple('ServiceModel', ('alias', 'service_type', 'endpoint', 'priority_requirement'))
+ServiceModel = namedtuple(
+    "ServiceModel", ("alias", "service_type", "endpoint", "priority_requirement")
+)

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,57 +4,76 @@ from pprint import pprint
 from factom import Factomd, FactomWalletd
 
 from did.did import DID, DID_METHOD_NAME, SignatureType, PurposeType
-from did.encryptor import decrypt_keys_from_str, decrypt_keys_from_json_str, \
-    decrypt_keys_from_json_file
+from did.encryptor import (
+    decrypt_keys_from_str,
+    decrypt_keys_from_json_str,
+    decrypt_keys_from_json_file,
+)
 
 
 # NOTE: You must set an EC_ADDR environment variable, which points to a funded
 # EC address, in order to be able to record DIDs on-chain
 factomd = Factomd()
 walletd = FactomWalletd()
-ec_address = os.environ.get('EC_ADDR')
+ec_address = os.environ.get("EC_ADDR")
 
 
 def create_new_did():
     new_did = DID()
 
-    '''Add new management key with default signature type and controller'''
-    management_key_1_alias = 'my-first-management-key'
+    """Add new management key with default signature type and controller"""
+    management_key_1_alias = "my-first-management-key"
     management_key_1_priority = 0
     new_did.add_management_key(management_key_1_alias, management_key_1_priority)
 
-    '''Add new management key with specified signature type and controller'''
-    management_key_2_alias = 'my-second-management-key'
+    """Add new management key with specified signature type and controller"""
+    management_key_2_alias = "my-second-management-key"
     management_key_2_priority = 2
     management_key_2_signature_type = SignatureType.ECDSA.value
-    management_key_2_controller = '{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005'.format(DID_METHOD_NAME)
-    new_did.add_management_key(management_key_2_alias, management_key_2_priority, management_key_2_signature_type,
-                               management_key_2_controller)
+    management_key_2_controller = "{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005".format(
+        DID_METHOD_NAME
+    )
+    new_did.add_management_key(
+        management_key_2_alias,
+        management_key_2_priority,
+        management_key_2_signature_type,
+        management_key_2_controller,
+    )
 
-    '''Add new public key with default signature type and controller'''
-    did_key_1_alias = 'my-did-key-1'
+    """Add new public key with default signature type and controller"""
+    did_key_1_alias = "my-did-key-1"
     did_key_1_purpose = [PurposeType.PublicKey.value]
     new_did.add_did_key(did_key_1_alias, did_key_1_purpose)
 
-    '''Add new authentication key with specified signature type'''
-    did_key_2_alias = 'my-did-key-2'
+    """Add new authentication key with specified signature type"""
+    did_key_2_alias = "my-did-key-2"
     did_key_2_purpose = [PurposeType.AuthenticationKey.value]
     did_key_2_signature_type = SignatureType.RSA.value
     new_did.add_did_key(did_key_2_alias, did_key_2_purpose, did_key_2_signature_type)
 
-    '''Add new both public and authentication key with specified signature type, controller and priority requirement'''
-    did_key_3_alias = 'my-did-key-3'
-    did_key_3_purpose = [PurposeType.PublicKey.value, PurposeType.AuthenticationKey.value]
+    """Add new both public and authentication key with specified signature type, controller and priority requirement"""
+    did_key_3_alias = "my-did-key-3"
+    did_key_3_purpose = [
+        PurposeType.PublicKey.value,
+        PurposeType.AuthenticationKey.value,
+    ]
     did_key_3_signature_type = SignatureType.EdDSA.value
-    did_key_3_controller = '{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005'.format(DID_METHOD_NAME)
+    did_key_3_controller = "{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005".format(
+        DID_METHOD_NAME
+    )
     did_key_3_priority_requirement = 2
-    new_did.add_did_key(did_key_3_alias, did_key_3_purpose, did_key_3_signature_type, did_key_3_controller,
-                        did_key_3_priority_requirement)
+    new_did.add_did_key(
+        did_key_3_alias,
+        did_key_3_purpose,
+        did_key_3_signature_type,
+        did_key_3_controller,
+        did_key_3_priority_requirement,
+    )
 
-    '''Add new service'''
-    service_alias = 'my-photo-service'
-    service_type = 'PhotoStreamService'
-    service_endpoint = 'https://myphoto.com'
+    """Add new service"""
+    service_alias = "my-photo-service"
+    service_type = "PhotoStreamService"
+    service_endpoint = "https://myphoto.com"
     new_did.add_service(service_alias, service_type, service_endpoint)
 
     return new_did
@@ -68,42 +87,48 @@ def record_did_on_chain():
 
 def encrypt_keys_as_str_and_decrypt():
     new_did = create_new_did()
-    keys_cipher_text = new_did.export_encrypted_keys_as_str('1234')
-    print('-----------------------------------Encrypted---------------------------------------')
+    keys_cipher_text = new_did.export_encrypted_keys_as_str("1234")
+    print(
+        "-----------------------------------Encrypted---------------------------------------"
+    )
     print(keys_cipher_text)
 
-    decrypted_keys = decrypt_keys_from_str(keys_cipher_text, '1234')
-    print('-----------------------------------Decrypted---------------------------------------')
+    decrypted_keys = decrypt_keys_from_str(keys_cipher_text, "1234")
+    print(
+        "-----------------------------------Decrypted---------------------------------------"
+    )
     pprint(decrypted_keys)
-    pprint(decrypted_keys[0]['alias'])
+    pprint(decrypted_keys[0]["alias"])
 
 
 def encrypt_keys_as_json_and_decrypt():
     new_did = create_new_did()
-    keys_json = new_did.export_encrypted_keys_as_json('1234')
-    print('-----------------------------------Encrypted---------------------------------------')
+    keys_json = new_did.export_encrypted_keys_as_json("1234")
+    print(
+        "-----------------------------------Encrypted---------------------------------------"
+    )
     pprint(keys_json)
 
-    decrypted_keys = decrypt_keys_from_json_str(keys_json, '1234')
-    print('-----------------------------------Decrypted---------------------------------------')
+    decrypted_keys = decrypt_keys_from_json_str(keys_json, "1234")
+    print(
+        "-----------------------------------Decrypted---------------------------------------"
+    )
     pprint(decrypted_keys)
-    pprint(decrypted_keys[0]['alias'])
+    pprint(decrypted_keys[0]["alias"])
 
 
 def decrypt_keys_from_file():
-    '''
+    """
     Decrypt keys from JSON file with a schema compatible to the one in
     DID.export_encrypted_keys_as_json()
-    '''
+    """
 
-    file_path = os.path.join(
-        'examples',
-        'paper-did-UTC--2019-08-06T10_51_19.432Z.txt')
-    password = '123qweASD!@#'
+    file_path = os.path.join("examples", "paper-did-UTC--2019-08-06T10_51_19.432Z.txt")
+    password = "123qweASD!@#"
     decrypted_keys = decrypt_keys_from_json_file(file_path, password)
     pprint(decrypted_keys)
-    pprint(decrypted_keys[0]['privateKey'])
+    pprint(decrypted_keys[0]["privateKey"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     record_did_on_chain()

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -3,8 +3,14 @@ import os
 import pytest
 import re
 
-from did.did import DID, SignatureType, PurposeType, ENTRY_SCHEMA_VERSION, \
-    DID_METHOD_SPEC_VERSION, DID_METHOD_NAME
+from did.did import (
+    DID,
+    SignatureType,
+    PurposeType,
+    ENTRY_SCHEMA_VERSION,
+    DID_METHOD_SPEC_VERSION,
+    DID_METHOD_NAME,
+)
 from did.enums import EntryType
 
 
@@ -13,7 +19,7 @@ def did():
     return DID()
 
 
-class TestEmptyDid():
+class TestEmptyDid:
     def test_generating_new_empty_did(self, did):
         assert re.search("^{}:[a-f0-9]{{64}}$".format(DID_METHOD_NAME), did.id)
         assert 64 == len(did.nonce)
@@ -24,9 +30,9 @@ class TestEmptyDid():
         assert set() == did.used_service_aliases
 
 
-class TestManagementKeys():
+class TestManagementKeys:
     def test_add_management_keys(self, did):
-        management_key_1_alias = 'management-key-1'
+        management_key_1_alias = "management-key-1"
         management_key_1_priority = 1
         did.add_management_key(management_key_1_alias, management_key_1_priority)
         generated_management_key_1 = did.management_keys[0]
@@ -38,40 +44,53 @@ class TestManagementKeys():
         assert generated_management_key_1.public_key is not None
         assert generated_management_key_1.private_key is not None
 
-        management_key_2_alias = 'management-key-2'
+        management_key_2_alias = "management-key-2"
         management_key_2_priority = 2
         management_key_2_signature_type = SignatureType.ECDSA.value
-        management_key_2_controller = \
-            '{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005'.format(DID_METHOD_NAME)
+        management_key_2_controller = "{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005".format(
+            DID_METHOD_NAME
+        )
 
-        did.add_management_key(management_key_2_alias, management_key_2_priority,
-                               management_key_2_signature_type, management_key_2_controller)
+        did.add_management_key(
+            management_key_2_alias,
+            management_key_2_priority,
+            management_key_2_signature_type,
+            management_key_2_controller,
+        )
         generated_management_key_2 = did.management_keys[1]
 
         assert management_key_2_alias == generated_management_key_2.alias
         assert management_key_2_priority == generated_management_key_2.priority
-        assert management_key_2_signature_type == generated_management_key_2.signature_type
+        assert (
+            management_key_2_signature_type == generated_management_key_2.signature_type
+        )
         assert management_key_2_controller == generated_management_key_2.controller
         assert generated_management_key_2.public_key is not None
         assert generated_management_key_2.private_key is not None
 
-        management_key_3_alias = 'management-key-3'
+        management_key_3_alias = "management-key-3"
         management_key_3_priority = 3
         management_key_3_signature_type = SignatureType.RSA.value
 
-        did.add_management_key(management_key_3_alias, management_key_3_priority, management_key_3_signature_type)
+        did.add_management_key(
+            management_key_3_alias,
+            management_key_3_priority,
+            management_key_3_signature_type,
+        )
         generated_management_key_3 = did.management_keys[2]
 
         assert management_key_3_alias == generated_management_key_3.alias
         assert management_key_3_priority == generated_management_key_3.priority
-        assert management_key_3_signature_type == generated_management_key_3.signature_type
+        assert (
+            management_key_3_signature_type == generated_management_key_3.signature_type
+        )
         assert did.id == generated_management_key_3.controller
         assert generated_management_key_3.public_key is not None
         assert generated_management_key_3.private_key is not None
         assert 3 == len(did.management_keys)
 
     def test_invalid_alias_throws_exception(self, did):
-        test_cases = ['myManagementKey', 'my-m@nagement-key', 'my_management_key']
+        test_cases = ["myManagementKey", "my-m@nagement-key", "my_management_key"]
         for alias in test_cases:
             with pytest.raises(ValueError):
                 did.add_management_key(alias, 1)
@@ -79,28 +98,42 @@ class TestManagementKeys():
     def test_invalid_priority_throws_exception(self, did):
         test_cases = [-1, -2]
         for priority in test_cases:
-            management_key_alias = 'management-key-{}'.format(str(priority))
+            management_key_alias = "management-key-{}".format(str(priority))
             with pytest.raises(ValueError):
                 did.add_management_key(management_key_alias, priority)
 
     def test_used_alias_throws_exception(self, did):
-        management_key_alias = 'management-key-1'
+        management_key_alias = "management-key-1"
         did.add_management_key(management_key_alias, 1)
         with pytest.raises(ValueError):
             did.add_management_key(management_key_alias, 1)
 
     def test_invalid_signature_type_throws_exception(self, did):
-        management_key_alias = 'management-key'
-        management_key_signature_type = 'invalid_signature_type'
+        management_key_alias = "management-key"
+        management_key_signature_type = "invalid_signature_type"
         with pytest.raises(ValueError):
-            did.add_management_key(management_key_alias, 1,
-                                                                          management_key_signature_type)
+            did.add_management_key(
+                management_key_alias, 1, management_key_signature_type
+            )
 
     def test_invalid_controller_throws_exception(self, did):
         test_cases = [
-            ('management-key-1', '{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654h05f838b8005'.format(DID_METHOD_NAME)),
-            ('management-key-2', 'did:fctr:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005'),
-            ('management-key-3', '{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b800'.format(DID_METHOD_NAME))
+            (
+                "management-key-1",
+                "{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654h05f838b8005".format(
+                    DID_METHOD_NAME
+                ),
+            ),
+            (
+                "management-key-2",
+                "did:fctr:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005",
+            ),
+            (
+                "management-key-3",
+                "{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b800".format(
+                    DID_METHOD_NAME
+                ),
+            ),
         ]
 
         for alias, controller in test_cases:
@@ -108,9 +141,9 @@ class TestManagementKeys():
                 did.add_management_key(alias, 1, SignatureType.EdDSA.value, controller)
 
 
-class DidKeysTestCase():
+class DidKeysTestCase:
     def test_add_did_keys(self, did):
-        did_key_1_alias = 'did-key-1'
+        did_key_1_alias = "did-key-1"
         did_key_1_purpose = [PurposeType.PublicKey.value]
         did.add_did_key(did_key_1_alias, did_key_1_purpose)
         generated_did_key_1 = did.did_keys[0]
@@ -121,71 +154,100 @@ class DidKeysTestCase():
         assert did.id == generated_did_key_1.controller
         assert None == generated_did_key_1.priority_requirement
 
-        did_key_2_alias = 'did-key-2'
-        did_key_2_purpose = [PurposeType.PublicKey.value, PurposeType.AuthenticationKey.value]
+        did_key_2_alias = "did-key-2"
+        did_key_2_purpose = [
+            PurposeType.PublicKey.value,
+            PurposeType.AuthenticationKey.value,
+        ]
         did_key_2_signature_type = SignatureType.ECDSA.value
-        did_key_2_controller = '{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005'.format(DID_METHOD_NAME)
+        did_key_2_controller = "{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005".format(
+            DID_METHOD_NAME
+        )
         did_key_2_priority_requirement = 1
-        did.add_did_key(did_key_2_alias, did_key_2_purpose, did_key_2_signature_type, did_key_2_controller,
-                             did_key_2_priority_requirement)
+        did.add_did_key(
+            did_key_2_alias,
+            did_key_2_purpose,
+            did_key_2_signature_type,
+            did_key_2_controller,
+            did_key_2_priority_requirement,
+        )
         generated_did_key_2 = did.did_keys[1]
 
         assert did_key_2_alias == generated_did_key_2.alias
         assert set(did_key_2_purpose) == generated_did_key_2.purpose
         assert did_key_2_signature_type == generated_did_key_2.signature_type
         assert did_key_2_controller == generated_did_key_2.controller
-        assert did_key_2_priority_requirement == generated_did_key_2.priority_requirement
+        assert (
+            did_key_2_priority_requirement == generated_did_key_2.priority_requirement
+        )
         assert 2 == len(did.did_keys)
 
     def test_invalid_alias_throws_exception(self, did):
-        test_cases = ['myDidKey', 'my-d!d-key', 'my_did_key']
+        test_cases = ["myDidKey", "my-d!d-key", "my_did_key"]
         for alias in test_cases:
             with pytest.raises(ValueError):
                 did.add_did_key(alias, [PurposeType.PublicKey.value])
 
     def test_invalid_purpose_type_throws_exception(self):
-        did_key_alias = 'did-key'
-        did_key_purpose = [PurposeType.PublicKey.value, 'InvalidPurposeType']
+        did_key_alias = "did-key"
+        did_key_purpose = [PurposeType.PublicKey.value, "InvalidPurposeType"]
         with pytest.raises(ValueError):
             did.add_did_key(did_key_alias, did_key_purpose)
 
     def test_used_alias_throws_exception(self):
-        alias = 'my-key-1'
+        alias = "my-key-1"
         did.add_management_key(alias, 1)
         with pytest.raises(ValueError):
             did.add_did_key(alias, [PurposeType.PublicKey.value])
 
     def test_invalid_signature_type_throws_exception(self):
-        did_key_alias = 'management-key'
-        did_key_signature_type = 'invalid_signature_type'
+        did_key_alias = "management-key"
+        did_key_signature_type = "invalid_signature_type"
         with pytest.raises(ValueError):
-            did.add_did_key(did_key_alias, [PurposeType.PublicKey.value],
-                                                                          did_key_signature_type)
+            did.add_did_key(
+                did_key_alias, [PurposeType.PublicKey.value], did_key_signature_type
+            )
 
     def test_invalid_controller_throws_exception(self):
         test_cases = [
-            ('did-key-1', 'did:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005'),
-            ('did-key-2', 'did:fctr:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b800')
+            (
+                "did-key-1",
+                "did:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005",
+            ),
+            (
+                "did-key-2",
+                "did:fctr:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b800",
+            ),
         ]
 
         for alias, controller in test_cases:
             with pytest.raises(ValueError):
-                did.add_did_key(alias, [PurposeType.PublicKey.value], SignatureType.EdDSA.value, controller)
+                did.add_did_key(
+                    alias,
+                    [PurposeType.PublicKey.value],
+                    SignatureType.EdDSA.value,
+                    controller,
+                )
 
     def test_invalid_priority_requirement_throws_exception(self):
         test_cases = [-1, -2]
         for priority_requirement in test_cases:
-            did_key_alias = 'did-key-{}'.format(str(priority_requirement))
+            did_key_alias = "did-key-{}".format(str(priority_requirement))
             with pytest.raises(ValueError):
-                did.add_did_key(did_key_alias, [PurposeType.PublicKey.value],
-                                SignatureType.EdDSA.value, None, priority_requirement)
+                did.add_did_key(
+                    did_key_alias,
+                    [PurposeType.PublicKey.value],
+                    SignatureType.EdDSA.value,
+                    None,
+                    priority_requirement,
+                )
 
 
-class TestService():
+class TestService:
     def test_add_service(self, did):
-        service_1_alias = 'photo-service'
-        service_1_type = 'PhotoStreamService'
-        service_1_endpoint = 'https://myphoto.com'
+        service_1_alias = "photo-service"
+        service_1_type = "PhotoStreamService"
+        service_1_endpoint = "https://myphoto.com"
         did.add_service(service_1_alias, service_1_type, service_1_endpoint)
         generated_service_1 = did.services[0]
 
@@ -194,47 +256,54 @@ class TestService():
         assert service_1_endpoint == generated_service_1.endpoint
         assert generated_service_1.priority_requirement is None
 
-        service_2_alias = 'auth-service'
-        service_2_type = 'AuthenticationService'
-        service_2_endpoint = 'https://authenticateme.com'
+        service_2_alias = "auth-service"
+        service_2_type = "AuthenticationService"
+        service_2_endpoint = "https://authenticateme.com"
         service_2_priority_requirement = 2
-        did.add_service(service_2_alias, service_2_type, service_2_endpoint, service_2_priority_requirement)
+        did.add_service(
+            service_2_alias,
+            service_2_type,
+            service_2_endpoint,
+            service_2_priority_requirement,
+        )
         generated_service_2 = did.services[1]
 
         assert service_2_alias == generated_service_2.alias
         assert service_2_type == generated_service_2.service_type
         assert service_2_endpoint == generated_service_2.endpoint
-        assert service_2_priority_requirement == generated_service_2.priority_requirement
+        assert (
+            service_2_priority_requirement == generated_service_2.priority_requirement
+        )
         assert 2 == len(did.services)
 
     def test_invalid_alias_throws_exception(self, did):
-        service_type = 'PhotoStreamService'
-        service_endpoint = 'https://myphoto.com'
-        test_cases = ['myPhotoService', 'my-ph@to-service', 'my_photo_service']
+        service_type = "PhotoStreamService"
+        service_endpoint = "https://myphoto.com"
+        test_cases = ["myPhotoService", "my-ph@to-service", "my_photo_service"]
         for alias in test_cases:
             with pytest.raises(ValueError):
                 did.add_service(alias, service_type, service_endpoint)
 
     def test_used_alias_throws_exception(self, did):
-        service_alias = 'my-photo-service'
-        service_type = 'PhotoStreamService'
-        service_endpoint = 'https://myphoto.com'
+        service_alias = "my-photo-service"
+        service_type = "PhotoStreamService"
+        service_endpoint = "https://myphoto.com"
         did.add_service(service_alias, service_type, service_endpoint)
         with pytest.raises(ValueError):
             did.add_service(service_alias, service_type, service_endpoint)
 
     def test_empty_service_type_throws_exception(self, did):
-        service_alias = 'my-photo-service'
-        service_type = ''
-        service_endpoint = 'https://myphoto.com'
+        service_alias = "my-photo-service"
+        service_type = ""
+        service_endpoint = "https://myphoto.com"
         with pytest.raises(ValueError):
             did.add_service(service_alias, service_type, service_endpoint)
 
     def test_invalid_endpoint_throws_exception(self, did):
-        service_type = 'PhotoStreamService'
+        service_type = "PhotoStreamService"
         test_cases = [
-            ('service-1', 'myservice.com'),
-            ('service-2', 'https//myphoto.com')
+            ("service-1", "myservice.com"),
+            ("service-2", "https//myphoto.com"),
         ]
 
         for alias, endpoint in test_cases:
@@ -242,90 +311,107 @@ class TestService():
                 did.add_service(alias, service_type, endpoint)
 
     def test_invalid_priority_requirement_throws_exception(self, did):
-        service_type = 'PhotoStreamService'
-        service_endpoint = 'https://myphoto.com'
+        service_type = "PhotoStreamService"
+        service_endpoint = "https://myphoto.com"
         test_cases = [-1, -2]
         for priority_requirement in test_cases:
-            service_alias = 'service-{}'.format(str(priority_requirement))
+            service_alias = "service-{}".format(str(priority_requirement))
             with pytest.raises(ValueError):
-                did.add_service(service_alias, service_type, service_endpoint, priority_requirement)
+                did.add_service(
+                    service_alias, service_type, service_endpoint, priority_requirement
+                )
 
 
-class TestExportEntryData():
+class TestExportEntryData:
     def test_export_entry_data_returns_correct_ext_ids(self, did):
-        did.add_management_key('my-management-key', 0)
+        did.add_management_key("my-management-key", 0)
         entry_data = did.export_entry_data()
 
-        ext_ids = entry_data['ext_ids']
+        ext_ids = entry_data["ext_ids"]
         assert EntryType.Create.value == ext_ids[0]
         assert ENTRY_SCHEMA_VERSION == ext_ids[1]
         assert did.nonce == ext_ids[2]
 
     def test_export_entry_data_with_management_key(self, did):
-        key_alias = 'my-management-key'
+        key_alias = "my-management-key"
         key_priority = 0
         did.add_management_key(key_alias, key_priority)
         entry_data = did.export_entry_data()
 
-        content = json.loads(entry_data['content'])
-        assert DID_METHOD_SPEC_VERSION == content['didMethodVersion']
+        content = json.loads(entry_data["content"])
+        assert DID_METHOD_SPEC_VERSION == content["didMethodVersion"]
 
-        management_keys = content['managementKey']
+        management_keys = content["managementKey"]
         assert 1 == len(management_keys)
         with pytest.raises(KeyError):
-            content['didKey']
+            content["didKey"]
         with pytest.raises(KeyError):
-            content['service']
+            content["service"]
 
         management_key_1 = management_keys[0]
-        assert '{}#{}'.format(did.id, key_alias) == management_key_1['id']
-        assert '{}VerificationKey'.format(SignatureType.EdDSA.value) == management_key_1['type']
-        assert did.id == management_key_1['controller']
-        assert str(did.management_keys[0].public_key, 'utf8') == management_key_1['publicKeyBase58']
-        assert key_priority == management_key_1['priority']
+        assert "{}#{}".format(did.id, key_alias) == management_key_1["id"]
+        assert (
+            "{}VerificationKey".format(SignatureType.EdDSA.value)
+            == management_key_1["type"]
+        )
+        assert did.id == management_key_1["controller"]
+        assert (
+            str(did.management_keys[0].public_key, "utf8")
+            == management_key_1["publicKeyBase58"]
+        )
+        assert key_priority == management_key_1["priority"]
 
     def test_export_entry_data_with_did_key_and_service(self, did):
-        did_key_alias = 'my-public-key'
+        did_key_alias = "my-public-key"
         did_key_purpose = [PurposeType.PublicKey.value]
         did_key_signature_type = SignatureType.RSA.value
-        did_key_controller = '{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005'.format(DID_METHOD_NAME)
+        did_key_controller = "{}:d3936b2f0bdd45fe71d7156e835434b7970afd78868076f56654d05f838b8005".format(
+            DID_METHOD_NAME
+        )
         did_key_priority_requirement = 1
-        service_alias = 'my-photo-service'
-        service_type = 'PhotoStreamService'
-        service_endpoint = 'https://myphoto.com'
+        service_alias = "my-photo-service"
+        service_type = "PhotoStreamService"
+        service_endpoint = "https://myphoto.com"
         service_priority_requirement = 2
-        did.add_management_key('my-management-key-1', 0)
-        did.add_management_key('my-management-key-2', 2)
-        did.add_did_key(did_key_alias, did_key_purpose, did_key_signature_type, did_key_controller,
-                             did_key_priority_requirement)
-        did.add_service(service_alias, service_type, service_endpoint, service_priority_requirement)
+        did.add_management_key("my-management-key-1", 0)
+        did.add_management_key("my-management-key-2", 2)
+        did.add_did_key(
+            did_key_alias,
+            did_key_purpose,
+            did_key_signature_type,
+            did_key_controller,
+            did_key_priority_requirement,
+        )
+        did.add_service(
+            service_alias, service_type, service_endpoint, service_priority_requirement
+        )
         entry_data = did.export_entry_data()
-        content = json.loads(entry_data['content'])
+        content = json.loads(entry_data["content"])
 
-        management_keys = content['managementKey']
-        did_keys = content['didKey']
-        services = content['service']
+        management_keys = content["managementKey"]
+        did_keys = content["didKey"]
+        services = content["service"]
         assert 2 == len(management_keys)
         assert 1 == len(did_keys)
         assert 1 == len(services)
 
         did_key_1 = did_keys[0]
-        assert '{}#{}'.format(did.id, did_key_alias) == did_key_1['id']
-        assert '{}VerificationKey'.format(did_key_signature_type) == did_key_1['type']
-        assert did_key_controller == did_key_1['controller']
-        assert str(did.did_keys[0].public_key, 'utf8') == did_key_1['publicKeyPem']
-        assert did_key_purpose == did_key_1['purpose']
-        assert did_key_priority_requirement == did_key_1['priorityRequirement']
+        assert "{}#{}".format(did.id, did_key_alias) == did_key_1["id"]
+        assert "{}VerificationKey".format(did_key_signature_type) == did_key_1["type"]
+        assert did_key_controller == did_key_1["controller"]
+        assert str(did.did_keys[0].public_key, "utf8") == did_key_1["publicKeyPem"]
+        assert did_key_purpose == did_key_1["purpose"]
+        assert did_key_priority_requirement == did_key_1["priorityRequirement"]
 
         service_1 = services[0]
-        assert '{}#{}'.format(did.id, service_alias) == service_1['id']
-        assert service_type == service_1['type']
-        assert service_endpoint == service_1['serviceEndpoint']
-        assert service_priority_requirement == service_1['priorityRequirement']
+        assert "{}#{}".format(did.id, service_alias) == service_1["id"]
+        assert service_type == service_1["type"]
+        assert service_endpoint == service_1["serviceEndpoint"]
+        assert service_priority_requirement == service_1["priorityRequirement"]
 
     def test_exceed_entry_size_throws_error(self, did):
         for x in range(0, 35):
-            did.add_management_key('management-key-{}'.format(x), 0)
+            did.add_management_key("management-key-{}".format(x), 0)
 
         with pytest.raises(ValueError):
             did.export_entry_data()

--- a/tests/test_encryptor.py
+++ b/tests/test_encryptor.py
@@ -2,7 +2,11 @@ import os
 import pytest
 
 from did.did import DID
-from did.encryptor import decrypt_keys_from_str, decrypt_keys_from_json_str, decrypt_keys_from_json_file
+from did.encryptor import (
+    decrypt_keys_from_str,
+    decrypt_keys_from_json_str,
+    decrypt_keys_from_json_file,
+)
 
 
 @pytest.fixture
@@ -10,84 +14,97 @@ def did():
     return DID()
 
 
-class TestEncryptor():
+class TestEncryptor:
     def test_encrypt_as_str_and_decrypt(self, did):
-        did.add_management_key('management-key', 1)
+        did.add_management_key("management-key", 1)
         generated_management_key = did.management_keys[0]
 
-        password = '123456'
+        password = "123456"
         encrypted_keys_cipher_b64 = did.export_encrypted_keys_as_str(password)
         decrypted_keys = decrypt_keys_from_str(encrypted_keys_cipher_b64, password)
         decrypted_management_key = decrypted_keys[0]
 
-        assert generated_management_key.alias == decrypted_management_key['alias']
-        assert generated_management_key.signature_type == decrypted_management_key['type']
-        assert str(generated_management_key.private_key, 'utf8') == decrypted_management_key['privateKey']
+        assert generated_management_key.alias == decrypted_management_key["alias"]
+        assert (
+            generated_management_key.signature_type == decrypted_management_key["type"]
+        )
+        assert (
+            str(generated_management_key.private_key, "utf8")
+            == decrypted_management_key["privateKey"]
+        )
 
     def test_encrypt_as_str_and_decrypt_with_invalid_password_throws_error(self, did):
-        did.add_management_key('management-key', 1)
+        did.add_management_key("management-key", 1)
 
-        password = '123456'
+        password = "123456"
         encrypted_keys_cipher_b64 = did.export_encrypted_keys_as_str(password)
 
-        invalid_password = '12345'
+        invalid_password = "12345"
         with pytest.raises(ValueError):
             decrypt_keys_from_str(encrypted_keys_cipher_b64, invalid_password)
 
-    def test_encrypt_as_str_and_decrypt_with_invalid_cipher_text_throws_error(self, did):
-        did.add_management_key('management-key', 1)
+    def test_encrypt_as_str_and_decrypt_with_invalid_cipher_text_throws_error(
+        self, did
+    ):
+        did.add_management_key("management-key", 1)
 
-        password = '123456'
+        password = "123456"
         encrypted_keys_cipher_b64 = did.export_encrypted_keys_as_str(password)
 
         with pytest.raises(ValueError):
             decrypt_keys_from_str(encrypted_keys_cipher_b64[:24], password)
 
     def test_encrypt_as_json_and_decrypt(self, did):
-        did.add_management_key('management-key', 1)
+        did.add_management_key("management-key", 1)
         generated_management_key = did.management_keys[0]
 
-        password = '123456'
+        password = "123456"
         encrypted_keys_json = did.export_encrypted_keys_as_json(password)
         decrypted_keys = decrypt_keys_from_json_str(encrypted_keys_json, password)
         decrypted_management_key = decrypted_keys[0]
 
-        assert generated_management_key.alias == decrypted_management_key['alias']
-        assert generated_management_key.signature_type == decrypted_management_key['type']
-        assert str(generated_management_key.private_key, 'utf8') == decrypted_management_key['privateKey']
+        assert generated_management_key.alias == decrypted_management_key["alias"]
+        assert (
+            generated_management_key.signature_type == decrypted_management_key["type"]
+        )
+        assert (
+            str(generated_management_key.private_key, "utf8")
+            == decrypted_management_key["privateKey"]
+        )
 
     def test_encrypt_as_json_and_decrypt_with_invalid_password_throws_error(self, did):
-        did.add_management_key('management-key', 1)
+        did.add_management_key("management-key", 1)
 
-        password = '123456'
+        password = "123456"
         encrypted_keys_json = did.export_encrypted_keys_as_json(password)
 
-        invalid_password = '!23456'
+        invalid_password = "!23456"
         with pytest.raises(ValueError):
             decrypt_keys_from_json_str(encrypted_keys_json, invalid_password)
 
     def test_encrypt_as_json_and_decrypt_with_invalid_json_throws_error(self):
-        invalid_json = '{"data": "KuZTmv2xmw4N+GFYNCBuqMgt8OEO24hHABPJBKjxehmqI2I0UZwzIjqf2acI8DnfYQTs0uVZxetLri'
-        password = '123qweASD!@#'
+        invalid_json = '{"data": "KuZTmv2xmw4N+GFYNCBuqMgt8OEO24hHABPJBKjxehmqI2I0UZwzIjqf2acI8DnfYQTs0uVZxetLri"'
+        password = "123qweASD!@#"
         with pytest.raises(ValueError):
             decrypt_keys_from_json_str(invalid_json, password)
 
     def test_encrypt_as_json_and_decrypt_with_missing_json_property_throws_error(self):
         # data property is missing from the json
         invalid_json = '{"encryptionAlgo": {"name": "AES-GCM","iv": "vLsvUFfZJ3nUe/G3GHFK1A==","salt": "GynGAsqMaVbmMviTSkx6htQpDcgL4pQ8UQRdann/Jzo=","tagLength": 128},"did": "did:fctr:3626da39a85becd84c203676bd99707723290a06ea0663d3eade8a2301910573"}'
-        password = '123qweASD!@#'
+        password = "123qweASD!@#"
         with pytest.raises(KeyError):
             decrypt_keys_from_json_str(invalid_json, password)
 
     def test_decrypt_keys_from_file(self):
-        file_path = os.path.join('tests', 'fixtures',
-            'paper-did-UTC--2019-08-06T10_51_19.432Z.txt')
-        password = '123qweASD!@#'
+        file_path = os.path.join(
+            "tests", "fixtures", "paper-did-UTC--2019-08-06T10_51_19.432Z.txt"
+        )
+        password = "123qweASD!@#"
         expected_keys = [
             {
                 "alias": "defaultpubkey",
                 "type": "Ed25519",
-                "privateKey": "AjSQe96djVuNrh2izoFrwtPFcjL5XencKRYuArbRmJpqAZtEsbJhhYYmS5KdEmCd46hjJ3fGWuRb5jeEUKgPada"
+                "privateKey": "AjSQe96djVuNrh2izoFrwtPFcjL5XencKRYuArbRmJpqAZtEsbJhhYYmS5KdEmCd46hjJ3fGWuRb5jeEUKgPada",
             }
         ]
 
@@ -95,8 +112,9 @@ class TestEncryptor():
         assert expected_keys == decrypted_keys
 
     def test_decrypt_keys_from_file_with_invalid_password_throws_error(self):
-        file_path = os.path.join('tests', 'fixtures',
-            'paper-did-UTC--2019-08-06T10_51_19.432Z.txt')
-        invalid_password = 'qweASD!@#'
+        file_path = os.path.join(
+            "tests", "fixtures", "paper-did-UTC--2019-08-06T10_51_19.432Z.txt"
+        )
+        invalid_password = "qweASD!@#"
         with pytest.raises(ValueError):
             decrypt_keys_from_json_file(file_path, invalid_password)


### PR DESCRIPTION
This PR adds automated code formatting to the library using [black](https://github.com/psf/black).

I've added a pre-commit hook configuration, which can be used to auto-format the code before it's committed. Alternatively, it's possible to configure black to be called automatically upon saving of the file (check the documentation from the link above).