### PR TITLE
Add resolver entry validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
 - pip install pipenv
 - pipenv install -d --pre
 script:
-- pytest --cov=./client/
+- pytest --cov=./client/ --cov=./resolver
 after_success:
 - coveralls

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,8 @@ base58 = "*"
 ecdsa = "*"
 ed25519 = "*"
 factom-api = "*"
+jsonschema = "*"
+jsonref = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "97a13d8434b928994ae938abca56655d1ccaee9849953c835ab1e1d7f8cceb4e"
+            "sha256": "f87e2731064d531bf5721cff7412ea5b8dd53da50a421ef521dde0a8250aec51"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
         "base58": {
             "hashes": [
                 "sha256:1e42993c0628ed4f898c03b522b26af78fb05115732549b21a028bc4633d19ab",
@@ -69,6 +76,22 @@
             ],
             "version": "==2.8"
         },
+        "jsonref": {
+            "hashes": [
+                "sha256:b1e82fa0b62e2c2796a13e5401fe51790b248f6d9bf9d7212a3e31a3501b291f",
+                "sha256:f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697"
+            ],
+            "index": "pypi",
+            "version": "==0.2"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f",
+                "sha256:8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
+        },
         "pycryptodome": {
             "hashes": [
                 "sha256:023c294367d7189ae224fb61bc8d49a2347704087c1c78dbd5ab114dd5b97761",
@@ -103,12 +126,25 @@
             "index": "pypi",
             "version": "==3.9.0"
         },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533"
+            ],
+            "version": "==0.15.4"
+        },
         "requests": {
             "hashes": [
                 "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
                 "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "version": "==2.22.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         },
         "urllib3": {
             "hashes": [
@@ -279,11 +315,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:652234b6ab8f2506ae58e528b6fbcc668831d3cc758e1bc01ef438d328b68cdb",
-                "sha256:6f264986fb88042bc1f0535fa9a557e6a376cfe5679dc77caac7fe8b5d43d05f"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.22"
+            "version": "==0.23"
         },
         "jinja2": {
             "hashes": [

--- a/client/enums.py
+++ b/client/enums.py
@@ -12,6 +12,7 @@ class SignatureType(Enum):
 class EntryType(Enum):
     Create = "DIDManagement"
     Update = "DIDUpdate"
+    VersionUpgrade = "DIDMethodVersionUpgrade"
 
 
 class DIDKeyPurpose(Enum):

--- a/client/enums.py
+++ b/client/enums.py
@@ -13,6 +13,7 @@ class EntryType(Enum):
     Create = "DIDManagement"
     Update = "DIDUpdate"
     VersionUpgrade = "DIDMethodVersionUpgrade"
+    Deactivation = "DIDDeactivation"
 
 
 class DIDKeyPurpose(Enum):

--- a/client/keys.py
+++ b/client/keys.py
@@ -239,7 +239,7 @@ class ManagementKey(AbstractDIDKey):
     Attributes
     ----------
     alias: str
-    priority: int
+    priority: int or str
         A non-negative integer showing the hierarchical level of the key. Keys with lower priority override keys with
         higher priority.
     signature_type: SignatureType
@@ -268,7 +268,7 @@ class ManagementKey(AbstractDIDKey):
             private_key,
         )
 
-        if priority < 0:
+        if int(priority) < 0:
             raise ValueError("Priority must be a non-negative integer.")
 
         self.priority = priority

--- a/client/updater.py
+++ b/client/updater.py
@@ -165,9 +165,13 @@ class DIDUpdater:
             update_key_required_priority = self._get_required_key_priority_for_update(
                 key, update_key_required_priority, lambda k: k.priority_requirement
             )
-            update_key_required_priority = self._get_required_key_priority_for_update(
-                key, update_key_required_priority, lambda k: k.priority
-            )
+            # Only use the priority property to compute the required key priority for the
+            # signing key, if priority_requirement is _not_ set. If it is set, it
+            # overrides the key priority.
+            if key.priority_requirement is None:
+                update_key_required_priority = self._get_required_key_priority_for_update(
+                    key, update_key_required_priority, lambda k: k.priority
+                )
         for key in revoked_did_keys:
             revoke_dict["didKey"].append({"id": key.alias})
             update_key_required_priority = self._get_required_key_priority_for_update(

--- a/resolver/exceptions.py
+++ b/resolver/exceptions.py
@@ -1,0 +1,2 @@
+class MalformedDIDManagementEntry(Exception):
+    pass

--- a/resolver/exceptions.py
+++ b/resolver/exceptions.py
@@ -1,2 +1,6 @@
 class MalformedDIDManagementEntry(Exception):
     pass
+
+
+class MalformedDIDUpdateEntry(Exception):
+    pass

--- a/resolver/exceptions.py
+++ b/resolver/exceptions.py
@@ -4,3 +4,7 @@ class MalformedDIDManagementEntry(Exception):
 
 class MalformedDIDUpdateEntry(Exception):
     pass
+
+
+class MalformedDIDMethodVersionUpgradeEntry(Exception):
+    pass

--- a/resolver/exceptions.py
+++ b/resolver/exceptions.py
@@ -8,3 +8,7 @@ class MalformedDIDUpdateEntry(Exception):
 
 class MalformedDIDMethodVersionUpgradeEntry(Exception):
     pass
+
+
+class MalformedDIDDeactivationEntry(Exception):
+    pass

--- a/resolver/schemas/1.0.0/did_key.json
+++ b/resolver/schemas/1.0.0/did_key.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DID key schema",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "type": {
+      "enum": ["Ed25519VerificationKey", "ECDSASecp256k1VerificationKey", "RSAVerificationKey"]
+    },
+    "controller": {"type": "string"},
+    "publicKeyBase58": {"type": "string"},
+    "publicKeyPem": {"type": "string"},
+    "purpose": {
+      "type": "array",
+      "items": {
+        "enum": ["publicKey", "authentication"]
+      },
+      "maxItems": 2,
+      "minItems": 1
+    },
+    "priorityRequirement": {"type": "string"},
+    "bip44": {"type": "string"}
+  },
+  "additionalProperties": false,
+  "required": ["id", "type", "controller", "purpose"],
+  "oneOf": [
+    {
+      "required": [
+        "publicKeyBase58"
+      ]
+    },
+    {
+      "required": [
+        "publicKeyPem"
+      ]
+    }
+  ]
+}
+

--- a/resolver/schemas/1.0.0/did_management_entry.json
+++ b/resolver/schemas/1.0.0/did_management_entry.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DIDManagement entry schema",
+  "type": "object",
+  "properties": {
+    "didMethodVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "managementKey": {
+      "type": "array",
+      "items": {"$ref": "management_key.json"}
+    },
+    "didKey": {
+      "type": "array",
+      "items": {"$ref": "did_key.json"}
+    },
+    "service": {
+      "type": "array",
+      "items": {"$ref": "service.json"}
+    }
+  },
+  "additionalProperties": false,
+  "required": ["didMethodVersion", "managementKey"]
+}
+

--- a/resolver/schemas/1.0.0/did_method_version_upgrade_entry.json
+++ b/resolver/schemas/1.0.0/did_method_version_upgrade_entry.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DIDMethodVersionUpgrade entry schema",
+  "type": "object",
+  "properties": {
+    "didMethodVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["didMethodVersion"]
+}
+

--- a/resolver/schemas/1.0.0/did_update_entry.json
+++ b/resolver/schemas/1.0.0/did_update_entry.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DIDUpdate entry schema",
+  "type": "object",
+  "properties": {
+    "revoke": {
+      "type": "object",
+      "properties": {
+        "managementKey": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {"type": "string"}
+            },
+            "required": ["id"]
+          }
+        },
+        "didKey": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {"type": "string"},
+              "purpose": {
+                "type": "array",
+                "items": {
+                  "enum": ["publicKey", "authentication"]
+                }
+              }
+            },
+            "required": ["id"]
+          }
+        },
+        "service": {
+          "type": "array",
+          "items":{
+            "type": "object",
+            "properties": {
+              "id": {"type": "string"}
+            },
+            "required": ["id"]
+          }
+        }
+      }
+    },
+    "add": {
+      "type": "object",
+      "properties": {
+        "managementKey": {
+          "type": "array",
+          "items": {"$ref": "management_key.json"}
+        },
+        "didKey": {
+          "type": "array",
+          "items": {"$ref": "did_key.json"}
+        },
+        "service": {
+          "type": "array",
+          "items": {"$ref": "service.json"}
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+

--- a/resolver/schemas/1.0.0/management_key.json
+++ b/resolver/schemas/1.0.0/management_key.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Management key schema",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "type": {
+      "enum": ["Ed25519VerificationKey", "ECDSASecp256k1VerificationKey", "RSAVerificationKey"]
+    },
+    "controller": {"type": "string"},
+    "publicKeyBase58": {"type": "string"},
+    "publicKeyPem": {"type": "string"},
+    "priority": {"type": "string"},
+    "priorityRequirement": {"type": "string"},
+    "bip44": {"type": "string"}
+  },
+  "additionalProperties": false,
+  "required": ["id", "type", "controller", "priority"],
+  "oneOf": [
+    {
+      "required": [
+        "publicKeyBase58"
+      ]
+    },
+    {
+      "required": [
+        "publicKeyPem"
+      ]
+    }
+  ]
+}
+

--- a/resolver/schemas/1.0.0/service.json
+++ b/resolver/schemas/1.0.0/service.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Service schema",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "type": {"type": "string"},
+    "serviceEndpoint": {"type": "string", "format": "uri"},
+    "priorityRequirement": {"type": "string"}
+  },
+  "additionalProperties": false,
+  "required": ["id", "type", "serviceEndpoint"]
+}
+

--- a/resolver/validators.py
+++ b/resolver/validators.py
@@ -3,6 +3,7 @@ import re
 from client.constants import DID_METHOD_NAME
 from client.enums import EntryType
 from resolver.exceptions import (
+    MalformedDIDDeactivationEntry,
     MalformedDIDManagementEntry,
     MalformedDIDMethodVersionUpgradeEntry,
     MalformedDIDUpdateEntry,
@@ -139,15 +140,15 @@ def validate_version_upgrade_entry_content(ext_ids, content, schema_validator):
             )
         )
     if ext_ids[0] != EntryType.Update.value:
-        raise MalformedDIDUpdateEntry(
+        raise MalformedDIDMethodVersionUpgradeEntry(
             "First ExtID of {} entry must be {}".format(
-                EntryType.Update.value, EntryType.Update.value
+                EntryType.VersionUpgrade.value, EntryType.VersionUpgrade.value
             )
         )
     if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
-        raise MalformedDIDUpdateEntry(
+        raise MalformedDIDMethodVersionUpgradeEntry(
             "Second ExtID of {} entry must be a semantic version number".format(
-                EntryType.Update.value
+                EntryType.VersionUpgrade.value
             )
         )
     if (
@@ -156,15 +157,15 @@ def validate_version_upgrade_entry_content(ext_ids, content, schema_validator):
         )
         is None
     ):
-        raise MalformedDIDUpdateEntry(
+        raise MalformedDIDMethodVersionUpgradeEntry(
             "Third ExtID of {} entry must be a valid full key identifier".format(
-                EntryType.Update.value
+                EntryType.VersionUpgrade.value
             )
         )
     if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
-        raise MalformedDIDUpdateEntry(
+        raise MalformedDIDMethodVersionUpgradeEntry(
             "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
-                EntryType.Update.value
+                EntryType.VersionUpgrade.value
             )
         )
 
@@ -174,4 +175,62 @@ def validate_version_upgrade_entry_content(ext_ids, content, schema_validator):
         raise MalformedDIDMethodVersionUpgradeEntry(
             "Malformed {} entry content".format(EntryType.VersionUpgrade.value)
         )
-    pass
+
+
+def validate_did_deactivation_entry_content(ext_ids, content):
+    """
+    Validates the format of a DIDDeactivation entry.
+
+    Parameters
+    ----------
+    ext_ids: list of str
+        The ExtIDs of the entry
+    content: dict
+        The entry content
+
+    Raises
+    ------
+    MalformedDIDDeactivationEntry
+        If the ExtIDs or the entry content do not follow the Factom DID method specification
+    """
+    if len(ext_ids) < 4:
+        raise MalformedDIDDeactivationEntry(
+            "{} entry must have at least four ExtIDs".format(
+                EntryType.Deactivation.value
+            )
+        )
+    if ext_ids[0] != EntryType.Update.value:
+        raise MalformedDIDDeactivationEntry(
+            "First ExtID of {} entry must be {}".format(
+                EntryType.Deactivation.value, EntryType.Deactivation.value
+            )
+        )
+    if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
+        raise MalformedDIDDeactivationEntry(
+            "Second ExtID of {} entry must be a semantic version number".format(
+                EntryType.Deactivation.value
+            )
+        )
+    if (
+        re.match(
+            r"^{}:[0-9a-f]{{64}}#[a-zA-Z0-9-]+$".format(DID_METHOD_NAME), ext_ids[2]
+        )
+        is None
+    ):
+        raise MalformedDIDDeactivationEntry(
+            "Third ExtID of {} entry must be a valid full key identifier".format(
+                EntryType.Deactivation.value
+            )
+        )
+    if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
+        raise MalformedDIDDeactivationEntry(
+            "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
+                EntryType.Deactivation.value
+            )
+        )
+
+    # The content of a DIDDeactivation entry must be empty
+    if content:
+        raise MalformedDIDDeactivationEntry(
+            "Malformed {} entry content".format(EntryType.Deactivation.value)
+        )

--- a/resolver/validators.py
+++ b/resolver/validators.py
@@ -8,6 +8,23 @@ from jsonschema.exceptions import ValidationError
 
 
 def validate_did_management_entry_format(ext_ids, content, schema_validator):
+    """
+    Validates the format of a DIDManagement entry.
+
+    Parameters
+    ----------
+    ext_ids: list of str
+        The ExtIDs of the entry
+    content: str
+        The entry content
+    schema_validator: jsonschema.validators.Draft7Validator
+        The entry content schema validator
+
+    Raises
+    ------
+    MalformedDIDManagementEntry
+        If the ExtIDs or the entry content do not follow the Factom DID method specification
+    """
     if len(ext_ids) < 2:
         raise MalformedDIDManagementEntry(
             "DIDManagement entry must have at least two ExtIDs"
@@ -30,6 +47,23 @@ def validate_did_management_entry_format(ext_ids, content, schema_validator):
 
 
 def validate_did_update_entry_format(ext_ids, content, schema_validator):
+    """
+    Validates the format of a DIDUpdate entry.
+
+    Parameters
+    ----------
+    ext_ids: list of str
+        The ExtIDs of the entry
+    content: str
+        The entry content
+    schema_validator: jsonschema.validators.Draft7Validator
+        The entry content schema validator
+
+    Raises
+    ------
+    MalformedDIDUpdateEntry
+        If the ExtIDs or the entry content do not follow the Factom DID method specification
+    """
     if len(ext_ids) < 4:
         raise MalformedDIDUpdateEntry("DIDUpdate entry must have at least four ExtIDs")
     if ext_ids[0] != EntryType.Update.value:

--- a/resolver/validators.py
+++ b/resolver/validators.py
@@ -1,0 +1,28 @@
+import re
+
+from client.enums import EntryType
+from resolver.exceptions import MalformedDIDManagementEntry
+
+from jsonschema.exceptions import ValidationError
+
+
+def validate_did_management_entry_format(ext_ids, content, schema_validator):
+    if len(ext_ids) < 2:
+        raise MalformedDIDManagementEntry(
+            "DIDManagement entry must have at least two ExtIDs"
+        )
+    if ext_ids[0] != EntryType.Create.value:
+        raise MalformedDIDManagementEntry(
+            "First ExtID of DIDManagement entry must be {}".format(
+                EntryType.Create.value
+            )
+        )
+    if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
+        raise MalformedDIDManagementEntry(
+            "Second ExtID of DIDManagement entry must be a semantic version number"
+        )
+
+    try:
+        schema_validator.validate(content)
+    except ValidationError:
+        raise MalformedDIDManagementEntry("Malformed DIDManagement entry content")

--- a/resolver/validators.py
+++ b/resolver/validators.py
@@ -2,7 +2,11 @@ import re
 
 from client.constants import DID_METHOD_NAME
 from client.enums import EntryType
-from resolver.exceptions import MalformedDIDManagementEntry, MalformedDIDUpdateEntry
+from resolver.exceptions import (
+    MalformedDIDManagementEntry,
+    MalformedDIDMethodVersionUpgradeEntry,
+    MalformedDIDUpdateEntry,
+)
 
 from jsonschema.exceptions import ValidationError
 
@@ -15,7 +19,7 @@ def validate_did_management_entry_format(ext_ids, content, schema_validator):
     ----------
     ext_ids: list of str
         The ExtIDs of the entry
-    content: str
+    content: dict
         The entry content
     schema_validator: jsonschema.validators.Draft7Validator
         The entry content schema validator
@@ -27,23 +31,27 @@ def validate_did_management_entry_format(ext_ids, content, schema_validator):
     """
     if len(ext_ids) < 2:
         raise MalformedDIDManagementEntry(
-            "DIDManagement entry must have at least two ExtIDs"
+            "{} entry must have at least two ExtIDs".format(EntryType.Create.value)
         )
     if ext_ids[0] != EntryType.Create.value:
         raise MalformedDIDManagementEntry(
-            "First ExtID of DIDManagement entry must be {}".format(
-                EntryType.Create.value
+            "First ExtID of {} entry must be {}".format(
+                EntryType.Create.value, EntryType.Create.value
             )
         )
     if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
         raise MalformedDIDManagementEntry(
-            "Second ExtID of DIDManagement entry must be a semantic version number"
+            "Second ExtID of {} entry must be a semantic version number".format(
+                EntryType.Create.value
+            )
         )
 
     try:
         schema_validator.validate(content)
     except ValidationError:
-        raise MalformedDIDManagementEntry("Malformed DIDManagement entry content")
+        raise MalformedDIDManagementEntry(
+            "Malformed {} entry content".format(EntryType.Create.value)
+        )
 
 
 def validate_did_update_entry_format(ext_ids, content, schema_validator):
@@ -54,7 +62,7 @@ def validate_did_update_entry_format(ext_ids, content, schema_validator):
     ----------
     ext_ids: list of str
         The ExtIDs of the entry
-    content: str
+    content: dict
         The entry content
     schema_validator: jsonschema.validators.Draft7Validator
         The entry content schema validator
@@ -65,14 +73,20 @@ def validate_did_update_entry_format(ext_ids, content, schema_validator):
         If the ExtIDs or the entry content do not follow the Factom DID method specification
     """
     if len(ext_ids) < 4:
-        raise MalformedDIDUpdateEntry("DIDUpdate entry must have at least four ExtIDs")
+        raise MalformedDIDUpdateEntry(
+            "{} entry must have at least four ExtIDs".format(EntryType.Update.value)
+        )
     if ext_ids[0] != EntryType.Update.value:
         raise MalformedDIDUpdateEntry(
-            "First ExtID of DIDUpdate entry must be {}".format(EntryType.Update.value)
+            "First ExtID of {} entry must be {}".format(
+                EntryType.Update.value, EntryType.Update.value
+            )
         )
     if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
         raise MalformedDIDUpdateEntry(
-            "Second ExtID of DIDUpdate entry must be a semantic version number"
+            "Second ExtID of {} entry must be a semantic version number".format(
+                EntryType.Update.value
+            )
         )
     if (
         re.match(
@@ -81,14 +95,83 @@ def validate_did_update_entry_format(ext_ids, content, schema_validator):
         is None
     ):
         raise MalformedDIDUpdateEntry(
-            "Third ExtID of DIDUpdate entry must be a valid full key identifier"
+            "Third ExtID of {} entry must be a valid full key identifier".format(
+                EntryType.Update.value
+            )
         )
     if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
         raise MalformedDIDUpdateEntry(
-            "Fourth ExtID of DIDUpdate entry must be a hex string with leading 0x"
+            "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
+                EntryType.Update.value
+            )
         )
 
     try:
         schema_validator.validate(content)
     except ValidationError:
-        raise MalformedDIDUpdateEntry("Malformed DIDUpdate entry content")
+        raise MalformedDIDUpdateEntry(
+            "Malformed {} entry content".format(EntryType.Update.value)
+        )
+
+
+def validate_version_upgrade_entry_content(ext_ids, content, schema_validator):
+    """
+    Validates the format of a DIDMethodVersionUpgrade entry.
+
+    Parameters
+    ----------
+    ext_ids: list of str
+        The ExtIDs of the entry
+    content: dict
+        The entry content
+    schema_validator: jsonschema.validators.Draft7Validator
+        The entry content schema validator
+
+    Raises
+    ------
+    MalformedDIDMethodVersionUpgradeEntry
+        If the ExtIDs or the entry content do not follow the Factom DID method specification
+    """
+    if len(ext_ids) < 4:
+        raise MalformedDIDMethodVersionUpgradeEntry(
+            "{} entry must have at least four ExtIDs".format(
+                EntryType.VersionUpgrade.value
+            )
+        )
+    if ext_ids[0] != EntryType.Update.value:
+        raise MalformedDIDUpdateEntry(
+            "First ExtID of {} entry must be {}".format(
+                EntryType.Update.value, EntryType.Update.value
+            )
+        )
+    if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
+        raise MalformedDIDUpdateEntry(
+            "Second ExtID of {} entry must be a semantic version number".format(
+                EntryType.Update.value
+            )
+        )
+    if (
+        re.match(
+            r"^{}:[0-9a-f]{{64}}#[a-zA-Z0-9-]+$".format(DID_METHOD_NAME), ext_ids[2]
+        )
+        is None
+    ):
+        raise MalformedDIDUpdateEntry(
+            "Third ExtID of {} entry must be a valid full key identifier".format(
+                EntryType.Update.value
+            )
+        )
+    if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
+        raise MalformedDIDUpdateEntry(
+            "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
+                EntryType.Update.value
+            )
+        )
+
+    try:
+        schema_validator.validate(content)
+    except ValidationError:
+        raise MalformedDIDMethodVersionUpgradeEntry(
+            "Malformed {} entry content".format(EntryType.VersionUpgrade.value)
+        )
+    pass

--- a/resolver/validators.py
+++ b/resolver/validators.py
@@ -30,22 +30,10 @@ def validate_did_management_entry_format(ext_ids, content, schema_validator):
     MalformedDIDManagementEntry
         If the ExtIDs or the entry content do not follow the Factom DID method specification
     """
-    if len(ext_ids) < 2:
-        raise MalformedDIDManagementEntry(
-            "{} entry must have at least two ExtIDs".format(EntryType.Create.value)
-        )
-    if ext_ids[0] != EntryType.Create.value:
-        raise MalformedDIDManagementEntry(
-            "First ExtID of {} entry must be {}".format(
-                EntryType.Create.value, EntryType.Create.value
-            )
-        )
-    if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
-        raise MalformedDIDManagementEntry(
-            "Second ExtID of {} entry must be a semantic version number".format(
-                EntryType.Create.value
-            )
-        )
+
+    _validate_ext_ids_length(ext_ids, 2, EntryType.Create, MalformedDIDManagementEntry)
+    _validate_entry_type(ext_ids, EntryType.Create, MalformedDIDManagementEntry)
+    _validate_schema_version(ext_ids, EntryType.Create, MalformedDIDManagementEntry)
 
     try:
         schema_validator.validate(content)
@@ -73,39 +61,11 @@ def validate_did_update_entry_format(ext_ids, content, schema_validator):
     MalformedDIDUpdateEntry
         If the ExtIDs or the entry content do not follow the Factom DID method specification
     """
-    if len(ext_ids) < 4:
-        raise MalformedDIDUpdateEntry(
-            "{} entry must have at least four ExtIDs".format(EntryType.Update.value)
-        )
-    if ext_ids[0] != EntryType.Update.value:
-        raise MalformedDIDUpdateEntry(
-            "First ExtID of {} entry must be {}".format(
-                EntryType.Update.value, EntryType.Update.value
-            )
-        )
-    if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
-        raise MalformedDIDUpdateEntry(
-            "Second ExtID of {} entry must be a semantic version number".format(
-                EntryType.Update.value
-            )
-        )
-    if (
-        re.match(
-            r"^{}:[0-9a-f]{{64}}#[a-zA-Z0-9-]+$".format(DID_METHOD_NAME), ext_ids[2]
-        )
-        is None
-    ):
-        raise MalformedDIDUpdateEntry(
-            "Third ExtID of {} entry must be a valid full key identifier".format(
-                EntryType.Update.value
-            )
-        )
-    if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
-        raise MalformedDIDUpdateEntry(
-            "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
-                EntryType.Update.value
-            )
-        )
+    _validate_ext_ids_length(ext_ids, 4, EntryType.Update, MalformedDIDUpdateEntry)
+    _validate_entry_type(ext_ids, EntryType.Update, MalformedDIDUpdateEntry)
+    _validate_schema_version(ext_ids, EntryType.Update, MalformedDIDUpdateEntry)
+    _validate_key_identifier(ext_ids, EntryType.Update, MalformedDIDUpdateEntry)
+    _validate_signature_format(ext_ids, EntryType.Update, MalformedDIDUpdateEntry)
 
     try:
         schema_validator.validate(content)
@@ -135,41 +95,21 @@ def validate_did_method_version_upgrade_entry_format(
     MalformedDIDMethodVersionUpgradeEntry
         If the ExtIDs or the entry content do not follow the Factom DID method specification
     """
-    if len(ext_ids) < 4:
-        raise MalformedDIDMethodVersionUpgradeEntry(
-            "{} entry must have at least four ExtIDs".format(
-                EntryType.VersionUpgrade.value
-            )
-        )
-    if ext_ids[0] != EntryType.VersionUpgrade.value:
-        raise MalformedDIDMethodVersionUpgradeEntry(
-            "First ExtID of {} entry must be {}".format(
-                EntryType.VersionUpgrade.value, EntryType.VersionUpgrade.value
-            )
-        )
-    if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
-        raise MalformedDIDMethodVersionUpgradeEntry(
-            "Second ExtID of {} entry must be a semantic version number".format(
-                EntryType.VersionUpgrade.value
-            )
-        )
-    if (
-        re.match(
-            r"^{}:[0-9a-f]{{64}}#[a-zA-Z0-9-]+$".format(DID_METHOD_NAME), ext_ids[2]
-        )
-        is None
-    ):
-        raise MalformedDIDMethodVersionUpgradeEntry(
-            "Third ExtID of {} entry must be a valid full key identifier".format(
-                EntryType.VersionUpgrade.value
-            )
-        )
-    if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
-        raise MalformedDIDMethodVersionUpgradeEntry(
-            "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
-                EntryType.VersionUpgrade.value
-            )
-        )
+    _validate_ext_ids_length(
+        ext_ids, 4, EntryType.VersionUpgrade, MalformedDIDMethodVersionUpgradeEntry
+    )
+    _validate_entry_type(
+        ext_ids, EntryType.VersionUpgrade, MalformedDIDMethodVersionUpgradeEntry
+    )
+    _validate_schema_version(
+        ext_ids, EntryType.VersionUpgrade, MalformedDIDMethodVersionUpgradeEntry
+    )
+    _validate_key_identifier(
+        ext_ids, EntryType.VersionUpgrade, MalformedDIDMethodVersionUpgradeEntry
+    )
+    _validate_signature_format(
+        ext_ids, EntryType.VersionUpgrade, MalformedDIDMethodVersionUpgradeEntry
+    )
 
     try:
         schema_validator.validate(content)
@@ -195,44 +135,70 @@ def validate_did_deactivation_entry_format(ext_ids, content):
     MalformedDIDDeactivationEntry
         If the ExtIDs or the entry content do not follow the Factom DID method specification
     """
-    if len(ext_ids) < 4:
+    _validate_ext_ids_length(
+        ext_ids, 4, EntryType.Deactivation, MalformedDIDDeactivationEntry
+    )
+    _validate_entry_type(ext_ids, EntryType.Deactivation, MalformedDIDDeactivationEntry)
+    _validate_schema_version(
+        ext_ids, EntryType.Deactivation, MalformedDIDDeactivationEntry
+    )
+    _validate_key_identifier(
+        ext_ids, EntryType.Deactivation, MalformedDIDDeactivationEntry
+    )
+    _validate_signature_format(
+        ext_ids, EntryType.Deactivation, MalformedDIDDeactivationEntry
+    )
+
+    # The content of a DIDDeactivation entry must be empty
+    if content:
         raise MalformedDIDDeactivationEntry(
-            "{} entry must have at least four ExtIDs".format(
-                EntryType.Deactivation.value
-            )
+            "Malformed {} entry content".format(EntryType.Deactivation.value)
         )
-    if ext_ids[0] != EntryType.Deactivation.value:
-        raise MalformedDIDDeactivationEntry(
+
+
+def _validate_ext_ids_length(ext_ids, min_length, entry_type, exception):
+    if len(ext_ids) < min_length:
+        raise exception(
+            "{} entry must have at least {} ExtIDs".format(entry_type.value, min_length)
+        )
+
+
+def _validate_entry_type(ext_ids, entry_type, exception):
+    if ext_ids[0] != entry_type.value:
+        raise exception(
             "First ExtID of {} entry must be {}".format(
-                EntryType.Deactivation.value, EntryType.Deactivation.value
+                entry_type.value, entry_type.value
             )
         )
+
+
+def _validate_schema_version(ext_ids, entry_type, exception):
     if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
-        raise MalformedDIDDeactivationEntry(
+        raise exception(
             "Second ExtID of {} entry must be a semantic version number".format(
-                EntryType.Deactivation.value
+                entry_type.value
             )
         )
+
+
+def _validate_key_identifier(ext_ids, entry_type, exception):
     if (
         re.match(
             r"^{}:[0-9a-f]{{64}}#[a-zA-Z0-9-]+$".format(DID_METHOD_NAME), ext_ids[2]
         )
         is None
     ):
-        raise MalformedDIDDeactivationEntry(
+        raise exception(
             "Third ExtID of {} entry must be a valid full key identifier".format(
-                EntryType.Deactivation.value
-            )
-        )
-    if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
-        raise MalformedDIDDeactivationEntry(
-            "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
-                EntryType.Deactivation.value
+                entry_type.value
             )
         )
 
-    # The content of a DIDDeactivation entry must be empty
-    if content:
-        raise MalformedDIDDeactivationEntry(
-            "Malformed {} entry content".format(EntryType.Deactivation.value)
+
+def _validate_signature_format(ext_ids, entry_type, exception):
+    if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
+        raise exception(
+            "Fourth ExtID of {} entry must be a hex string with leading 0x".format(
+                entry_type.value
+            )
         )

--- a/resolver/validators.py
+++ b/resolver/validators.py
@@ -1,7 +1,8 @@
 import re
 
+from client.constants import DID_METHOD_NAME
 from client.enums import EntryType
-from resolver.exceptions import MalformedDIDManagementEntry
+from resolver.exceptions import MalformedDIDManagementEntry, MalformedDIDUpdateEntry
 
 from jsonschema.exceptions import ValidationError
 
@@ -26,3 +27,34 @@ def validate_did_management_entry_format(ext_ids, content, schema_validator):
         schema_validator.validate(content)
     except ValidationError:
         raise MalformedDIDManagementEntry("Malformed DIDManagement entry content")
+
+
+def validate_did_update_entry_format(ext_ids, content, schema_validator):
+    if len(ext_ids) < 4:
+        raise MalformedDIDUpdateEntry("DIDUpdate entry must have at least four ExtIDs")
+    if ext_ids[0] != EntryType.Update.value:
+        raise MalformedDIDUpdateEntry(
+            "First ExtID of DIDUpdate entry must be {}".format(EntryType.Update.value)
+        )
+    if re.match(r"^\d+\.\d+\.\d+$", ext_ids[1]) is None:
+        raise MalformedDIDUpdateEntry(
+            "Second ExtID of DIDUpdate entry must be a semantic version number"
+        )
+    if (
+        re.match(
+            r"^{}:[0-9a-f]{{64}}#[a-zA-Z0-9-]+$".format(DID_METHOD_NAME), ext_ids[2]
+        )
+        is None
+    ):
+        raise MalformedDIDUpdateEntry(
+            "Third ExtID of DIDUpdate entry must be a valid full key identifier"
+        )
+    if re.match(r"^0x[0-9a-f]+$", ext_ids[3]) is None:
+        raise MalformedDIDUpdateEntry(
+            "Fourth ExtID of DIDUpdate entry must be a hex string with leading 0x"
+        )
+
+    try:
+        schema_validator.validate(content)
+    except ValidationError:
+        raise MalformedDIDUpdateEntry("Malformed DIDUpdate entry content")

--- a/resolver/validators.py
+++ b/resolver/validators.py
@@ -115,7 +115,9 @@ def validate_did_update_entry_format(ext_ids, content, schema_validator):
         )
 
 
-def validate_version_upgrade_entry_content(ext_ids, content, schema_validator):
+def validate_did_method_version_upgrade_entry_format(
+    ext_ids, content, schema_validator
+):
     """
     Validates the format of a DIDMethodVersionUpgrade entry.
 
@@ -139,7 +141,7 @@ def validate_version_upgrade_entry_content(ext_ids, content, schema_validator):
                 EntryType.VersionUpgrade.value
             )
         )
-    if ext_ids[0] != EntryType.Update.value:
+    if ext_ids[0] != EntryType.VersionUpgrade.value:
         raise MalformedDIDMethodVersionUpgradeEntry(
             "First ExtID of {} entry must be {}".format(
                 EntryType.VersionUpgrade.value, EntryType.VersionUpgrade.value
@@ -177,7 +179,7 @@ def validate_version_upgrade_entry_content(ext_ids, content, schema_validator):
         )
 
 
-def validate_did_deactivation_entry_content(ext_ids, content):
+def validate_did_deactivation_entry_format(ext_ids, content):
     """
     Validates the format of a DIDDeactivation entry.
 
@@ -199,7 +201,7 @@ def validate_did_deactivation_entry_content(ext_ids, content):
                 EntryType.Deactivation.value
             )
         )
-    if ext_ids[0] != EntryType.Update.value:
+    if ext_ids[0] != EntryType.Deactivation.value:
         raise MalformedDIDDeactivationEntry(
             "First ExtID of {} entry must be {}".format(
                 EntryType.Deactivation.value, EntryType.Deactivation.value

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,142 @@
+import json
+from os.path import abspath, dirname, join
+import secrets
+
+import pytest
+import jsonref
+from jsonschema.validators import validator_for
+
+from client.constants import DID_METHOD_NAME
+from client.enums import DIDKeyPurpose, SignatureType
+from client.keys import ManagementKey, DIDKey
+from client.service import Service
+from resolver.exceptions import MalformedDIDManagementEntry
+from resolver.validators import validate_did_management_entry_format
+
+
+def load_json_schema(filename, version="1.0.0"):
+    """Loads the given schema file"""
+
+    relative_path = join("./resolver/schemas", version, filename)
+    absolute_path = abspath(relative_path)
+
+    base_path = dirname(absolute_path)
+    base_uri = "file://{}/".format(base_path)
+
+    with open(absolute_path) as schema_file:
+        return jsonref.loads(schema_file.read(), base_uri=base_uri, jsonschema=True)
+
+
+def get_validator(schema):
+    cls = validator_for(schema)
+    cls.check_schema(schema)
+    return cls(schema)
+
+
+class TestDIDManagementEntryValidation:
+    DID_MANAGEMENT_VALIDATOR = get_validator(
+        load_json_schema("did_management_entry.json")
+    )
+
+    def test_insufficient_extids(self):
+        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
+            validate_did_management_entry_format([], "", self.DID_MANAGEMENT_VALIDATOR)
+        assert str(excinfo.value) == "DIDManagement entry must have at least two ExtIDs"
+
+        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
+            validate_did_management_entry_format(
+                ["DIDManagement"], "", self.DID_MANAGEMENT_VALIDATOR
+            )
+        assert str(excinfo.value) == "DIDManagement entry must have at least two ExtIDs"
+
+    def test_malformed_extids(self):
+        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
+            validate_did_management_entry_format(
+                ["DIdManagement", "1.0.0"], "", self.DID_MANAGEMENT_VALIDATOR
+            )
+        assert (
+            str(excinfo.value)
+            == "First ExtID of DIDManagement entry must be DIDManagement"
+        )
+
+        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
+            validate_did_management_entry_format(
+                ["DIDManagement", "1.0.a"], "", self.DID_MANAGEMENT_VALIDATOR
+            )
+        assert (
+            str(excinfo.value)
+            == "Second ExtID of DIDManagement entry must be a semantic version number"
+        )
+
+    def test_entry_with_missing_required_fields(self):
+        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
+            validate_did_management_entry_format(
+                ["DIDManagement", "1.0.0"], "{}", self.DID_MANAGEMENT_VALIDATOR
+            )
+        assert str(excinfo.value) == "Malformed DIDManagement entry content"
+
+        missing_management_keys = json.dumps({"didMethodVersion": "0.2.0"})
+        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
+            validate_did_management_entry_format(
+                ["DIDManagement", "1.0.0"],
+                missing_management_keys,
+                self.DID_MANAGEMENT_VALIDATOR,
+            )
+        assert str(excinfo.value) == "Malformed DIDManagement entry content"
+
+        did = "{}:{}".format(DID_METHOD_NAME, secrets.token_hex(32))
+        missing_did_method_version = {
+            "managementKey": [
+                ManagementKey(
+                    alias="my-man-key",
+                    controller=did,
+                    signature_type=SignatureType.EdDSA.value,
+                    priority="0",
+                ).to_entry_dict(did)
+            ]
+        }
+        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
+            validate_did_management_entry_format(
+                ["DIDManagement", "1.0.0"],
+                missing_did_method_version,
+                self.DID_MANAGEMENT_VALIDATOR,
+            )
+        assert str(excinfo.value) == "Malformed DIDManagement entry content"
+
+    def test_valid_entry(self):
+        did = "{}:{}".format(DID_METHOD_NAME, secrets.token_hex(32))
+        valid_entry = {
+            "didMethodVersion": "0.1.0",
+            "managementKey": [
+                ManagementKey(
+                    alias="my-man-key-1",
+                    controller=did,
+                    signature_type=SignatureType.EdDSA.value,
+                    priority="0",
+                ).to_entry_dict(did),
+                ManagementKey(
+                    alias="my-man-key-2",
+                    controller=did,
+                    signature_type=SignatureType.RSA.value,
+                    priority="1",
+                ).to_entry_dict(did),
+            ],
+            "didKey": [
+                DIDKey(
+                    alias="my-did-key",
+                    controller=did,
+                    signature_type=SignatureType.RSA.ECDSA.value,
+                    purpose=DIDKeyPurpose.PublicKey.value,
+                ).to_entry_dict(did)
+            ],
+            "service": [
+                Service(
+                    alias="gmail-service",
+                    service_type="email-service",
+                    endpoint="https://gmail.com",
+                ).to_entry_dict(did)
+            ],
+        }
+        validate_did_management_entry_format(
+            ["DIDManagement", "1.0.0"], valid_entry, self.DID_MANAGEMENT_VALIDATOR
+        )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -49,7 +49,7 @@ class TestDIDManagementEntryValidation:
     def test_insufficient_extids(self):
         with pytest.raises(MalformedDIDManagementEntry) as excinfo:
             validate_did_management_entry_format(["DIDManagement"], {}, self.VALIDATOR)
-        assert str(excinfo.value) == "DIDManagement entry must have at least two ExtIDs"
+        assert str(excinfo.value) == "DIDManagement entry must have at least 2 ExtIDs"
 
     def test_malformed_extids(self):
         with pytest.raises(MalformedDIDManagementEntry) as excinfo:
@@ -154,7 +154,7 @@ class TestDIDUpdateEntryValidation:
                 {},
                 self.VALIDATOR,
             )
-        assert str(excinfo.value) == "DIDUpdate entry must have at least four ExtIDs"
+        assert str(excinfo.value) == "DIDUpdate entry must have at least 4 ExtIDs"
 
     def test_malformed_extids(self):
         key_id = "{}:{}#{}".format(
@@ -392,7 +392,7 @@ class TestDIDMethodVersionUpgradeEntryValidation:
             )
         assert (
             str(excinfo.value)
-            == "DIDMethodVersionUpgrade entry must have at least four ExtIDs"
+            == "DIDMethodVersionUpgrade entry must have at least 4 ExtIDs"
         )
 
     def test_malformed_extids(self):
@@ -519,9 +519,7 @@ class TestDIDDeactivationEntryValidation:
                 ],
                 {},
             )
-        assert (
-            str(excinfo.value) == "DIDDeactivation entry must have at least four ExtIDs"
-        )
+        assert str(excinfo.value) == "DIDDeactivation entry must have at least 4 ExtIDs"
 
     def test_malformed_extids(self):
         key_id = "{}:{}#{}".format(

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -10,8 +10,11 @@ from client.constants import DID_METHOD_NAME
 from client.enums import DIDKeyPurpose, SignatureType
 from client.keys import DIDKey, ManagementKey
 from client.service import Service
-from resolver.exceptions import MalformedDIDManagementEntry
-from resolver.validators import validate_did_management_entry_format
+from resolver.exceptions import MalformedDIDManagementEntry, MalformedDIDUpdateEntry
+from resolver.validators import (
+    validate_did_management_entry_format,
+    validate_did_update_entry_format,
+)
 
 
 def load_json_schema(filename, version="1.0.0"):
@@ -39,10 +42,6 @@ class TestDIDManagementEntryValidation:
     )
 
     def test_insufficient_extids(self):
-        with pytest.raises(MalformedDIDManagementEntry) as excinfo:
-            validate_did_management_entry_format([], "", self.DID_MANAGEMENT_VALIDATOR)
-        assert str(excinfo.value) == "DIDManagement entry must have at least two ExtIDs"
-
         with pytest.raises(MalformedDIDManagementEntry) as excinfo:
             validate_did_management_entry_format(
                 ["DIDManagement"], "", self.DID_MANAGEMENT_VALIDATOR
@@ -139,4 +138,240 @@ class TestDIDManagementEntryValidation:
         }
         validate_did_management_entry_format(
             ["DIDManagement", "1.0.0"], valid_entry, self.DID_MANAGEMENT_VALIDATOR
+        )
+
+
+class TestDIDUpdateEntryValidation:
+    DID_UPDATE_VALIDATOR = get_validator(load_json_schema("did_update_entry.json"))
+
+    def test_insufficient_extids(self):
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                [
+                    "DIDUpdate",
+                    "1.0.0",
+                    "{}:{}#my-key".format(DID_METHOD_NAME, secrets.token_hex(32)),
+                ],
+                "",
+                self.DID_UPDATE_VALIDATOR,
+            )
+        assert str(excinfo.value) == "DIDUpdate entry must have at least four ExtIDs"
+
+    def test_malformed_extids(self):
+        key_id = "{}:{}#{}".format(
+            DID_METHOD_NAME, secrets.token_hex(32), "my-man-key-1"
+        )
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIdUpdate", "1.0.0", key_id, "0xaf01"], "", self.DID_UPDATE_VALIDATOR
+            )
+        assert str(excinfo.value) == "First ExtID of DIDUpdate entry must be DIDUpdate"
+
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIDUpdate", "1.0.", key_id, "0xaf01"], "", self.DID_UPDATE_VALIDATOR
+            )
+        assert (
+            str(excinfo.value)
+            == "Second ExtID of DIDUpdate entry must be a semantic version number"
+        )
+
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIDUpdate", "1.0.0", key_id[: key_id.find("#")], "0xaf01"],
+                "",
+                self.DID_UPDATE_VALIDATOR,
+            )
+        assert (
+            str(excinfo.value)
+            == "Third ExtID of DIDUpdate entry must be a valid full key identifier"
+        )
+
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIDUpdate", "1.0.0", key_id, "aff0"], "", self.DID_UPDATE_VALIDATOR
+            )
+        assert (
+            str(excinfo.value)
+            == "Fourth ExtID of DIDUpdate entry must be a hex string with leading 0x"
+        )
+
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIDUpdate", "1.0.0", key_id, "0xaffz"], "", self.DID_UPDATE_VALIDATOR
+            )
+        assert (
+            str(excinfo.value)
+            == "Fourth ExtID of DIDUpdate entry must be a hex string with leading 0x"
+        )
+
+    def test_invalid_entry(self):
+        did = "{}:{}".format(DID_METHOD_NAME, secrets.token_hex(32))
+        key_id = "{}#{}".format(did, "my-man-key-1")
+
+        # Entry with invalid property names
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIDUpdate", "1.0.0", key_id, "0xaffe"],
+                {
+                    "added": {
+                        "managementKey": [
+                            ManagementKey(
+                                alias="my-man-key-1",
+                                controller=did,
+                                signature_type=SignatureType.EdDSA.value,
+                                priority="0",
+                            ).to_entry_dict(did)
+                        ]
+                    }
+                },
+                self.DID_UPDATE_VALIDATOR,
+            )
+        assert str(excinfo.value) == "Malformed DIDUpdate entry content"
+
+        # Entry with invalid property names
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIDUpdate", "1.0.0", key_id, "0xaffe"],
+                {
+                    "add": {
+                        "managementKey": [
+                            ManagementKey(
+                                alias="my-man-key-1",
+                                controller=did,
+                                signature_type=SignatureType.EdDSA.value,
+                                priority="0",
+                            ).to_entry_dict(did)
+                        ]
+                    },
+                    "remove": {"managementKey": [{"id": "management-1"}]},
+                },
+                self.DID_UPDATE_VALIDATOR,
+            )
+        assert str(excinfo.value) == "Malformed DIDUpdate entry content"
+
+        # Entry with additional properties
+        with pytest.raises(MalformedDIDUpdateEntry) as excinfo:
+            validate_did_update_entry_format(
+                ["DIDUpdate", "1.0.0", key_id, "0xaffe"],
+                {
+                    "add": {
+                        "managementKey": [
+                            ManagementKey(
+                                alias="my-man-key-1",
+                                controller=did,
+                                signature_type=SignatureType.EdDSA.value,
+                                priority="0",
+                            ).to_entry_dict(did)
+                        ]
+                    },
+                    "revoke": {"managementKey": [{"id": "management-1"}]},
+                    "additional": {},
+                },
+                self.DID_UPDATE_VALIDATOR,
+            )
+        assert str(excinfo.value) == "Malformed DIDUpdate entry content"
+
+    def test_valid_entry(self):
+        did = "{}:{}".format(DID_METHOD_NAME, secrets.token_hex(32))
+        key_id = "{}#{}".format(did, "my-man-key-1")
+
+        # Empty entry content should be valid
+        validate_did_update_entry_format(
+            ["DIDUpdate", "1.0.0", key_id, "0xaffe"], {}, self.DID_UPDATE_VALIDATOR
+        )
+
+        # Entry with only additions should be valid
+        validate_did_update_entry_format(
+            ["DIDUpdate", "1.0.0", key_id, "0xaffe"],
+            {
+                "add": {
+                    "managementKey": [
+                        ManagementKey(
+                            alias="my-man-key-1",
+                            controller=did,
+                            signature_type=SignatureType.EdDSA.value,
+                            priority="0",
+                        ).to_entry_dict(did),
+                        ManagementKey(
+                            alias="my-man-key-2",
+                            controller=did,
+                            signature_type=SignatureType.RSA.value,
+                            priority="1",
+                        ).to_entry_dict(did),
+                    ],
+                    "didKey": [
+                        DIDKey(
+                            alias="my-did-key",
+                            controller=did,
+                            signature_type=SignatureType.RSA.ECDSA.value,
+                            purpose=DIDKeyPurpose.PublicKey.value,
+                        ).to_entry_dict(did)
+                    ],
+                }
+            },
+            self.DID_UPDATE_VALIDATOR,
+        )
+
+        # Entry with only revocations should be valid
+        validate_did_update_entry_format(
+            ["DIDUpdate", "1.0.0", key_id, "0xaffe"],
+            {
+                "revoke": {
+                    "managementKey": [{"id": "management-key-1"}],
+                    "didKey": [
+                        {"id": "did-key-1"},
+                        {"id": "did-key-2", "purpose": ["authentication"]},
+                    ],
+                    "service": [{"id": "service-1"}],
+                }
+            },
+            self.DID_UPDATE_VALIDATOR,
+        )
+
+        # Entry with both additions and revocations should be valid
+        validate_did_update_entry_format(
+            ["DIDUpdate", "1.0.0", key_id, "0xaffe"],
+            {
+                "add": {
+                    "managementKey": [
+                        ManagementKey(
+                            alias="my-man-key-1",
+                            controller=did,
+                            signature_type=SignatureType.EdDSA.value,
+                            priority="0",
+                        ).to_entry_dict(did),
+                        ManagementKey(
+                            alias="my-man-key-2",
+                            controller=did,
+                            signature_type=SignatureType.RSA.value,
+                            priority="1",
+                        ).to_entry_dict(did),
+                    ],
+                    "didKey": [
+                        DIDKey(
+                            alias="my-did-key",
+                            controller=did,
+                            signature_type=SignatureType.RSA.ECDSA.value,
+                            purpose=DIDKeyPurpose.PublicKey.value,
+                        ).to_entry_dict(did)
+                    ],
+                    "service": [
+                        Service(
+                            alias="gmail-service",
+                            service_type="email-service",
+                            endpoint="https://gmail.com",
+                        ).to_entry_dict(did)
+                    ],
+                },
+                "revoke": {
+                    "managementKey": [{"id": "management-key-1"}],
+                    "didKey": [
+                        {"id": "did-key-1"},
+                        {"id": "did-key-2", "purpose": ["publicKey"]},
+                    ],
+                    "service": [{"id": "service-1"}],
+                },
+            },
+            self.DID_UPDATE_VALIDATOR,
         )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,7 +8,7 @@ from jsonschema.validators import validator_for
 
 from client.constants import DID_METHOD_NAME
 from client.enums import DIDKeyPurpose, SignatureType
-from client.keys import ManagementKey, DIDKey
+from client.keys import DIDKey, ManagementKey
 from client.service import Service
 from resolver.exceptions import MalformedDIDManagementEntry
 from resolver.validators import validate_did_management_entry_format


### PR DESCRIPTION
Note that this PR only addresses validation of the format of the entries, but does not address business logic validation (such as checking validity of signatures, e.g.). Business logic validation will be added separately.

- [x] Add `DIDManagement` entry validation
  - [x] Add validators for ExtIDs
  - [x] Add JSON schema validation for entry content
  - [x] Add unit tests
- [x] Add `DIDUpdate` entry validation
  - [x] Add validators for ExtIDs
  - [x] Add JSON schema validation for entry content
  - [x] Add unit tests
- [x] Add `DIDMethodVersionUpgrade` entry validation
  - [x] Add validators for ExtIDs
  - [x] Add JSON schema validation for entry content
  - [x] Add unit tests
- [x] Add `DIDDeactivation` entry validation
  - [x] Add validators for ExtIDs
  - [x] Add JSON schema validation for entry content
  - [x] Add unit tests