### PR TITLE
Refactor client validators

### DIFF
--- a/factom_did/client/keys/abstract.py
+++ b/factom_did/client/keys/abstract.py
@@ -1,12 +1,16 @@
-import re
-
 import base58
 
-from factom_did.client.constants import DID_METHOD_NAME, ENTRY_SCHEMA_V100
-from factom_did.client.enums import KeyType, Network
+from factom_did.client.constants import ENTRY_SCHEMA_V100
+from factom_did.client.enums import KeyType
 from factom_did.client.keys.ecdsa import ECDSASecp256k1Key
 from factom_did.client.keys.eddsa import Ed25519Key
 from factom_did.client.keys.rsa import RSAKey
+from factom_did.client.validators import (
+    validate_alias,
+    validate_did,
+    validate_key_type,
+    validate_priority_requirement,
+)
 
 
 class AbstractDIDKey:
@@ -195,22 +199,7 @@ class AbstractDIDKey:
 
     @staticmethod
     def _validate_key_input_params(alias, key_type, controller, priority_requirement):
-        if not re.match("^[a-z0-9-]{1,32}$", alias):
-            raise ValueError(
-                "Alias must not be more than 32 characters long and must contain only lower-case "
-                "letters, digits and hyphens."
-            )
-
-        if key_type not in (KeyType.ECDSA, KeyType.EdDSA, KeyType.RSA):
-            raise ValueError("Type must be a valid signature type.")
-
-        if not re.match(
-            "^{}:({}:|{}:)?[a-f0-9]{{64}}$".format(
-                DID_METHOD_NAME, Network.Mainnet.value, Network.Testnet.value
-            ),
-            controller,
-        ):
-            raise ValueError("Controller must be a valid DID.")
-
-        if priority_requirement is not None and priority_requirement < 0:
-            raise ValueError("Priority requirement must be a non-negative integer.")
+        validate_alias(alias)
+        validate_key_type(key_type)
+        validate_did(controller)
+        validate_priority_requirement(priority_requirement)

--- a/factom_did/client/service.py
+++ b/factom_did/client/service.py
@@ -1,6 +1,9 @@
-import re
-
 from factom_did.client.constants import ENTRY_SCHEMA_V100
+from factom_did.client.validators import (
+    validate_alias,
+    validate_priority_requirement,
+    validate_service_endpoint,
+)
 
 __all__ = ["Service"]
 
@@ -119,22 +122,10 @@ class Service:
     def _validate_service_input_params(
         alias, service_type, endpoint, priority_requirement
     ):
-        if not re.match("^[a-z0-9-]{1,32}$", alias):
-            raise ValueError(
-                "Alias must not be more than 32 characters long and must contain only lower-case "
-                "letters, digits and hyphens."
-            )
+        validate_alias(alias)
 
         if not service_type:
             raise ValueError("Type is required.")
 
-        if not re.match(
-            r"^(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$",
-            endpoint,
-        ):
-            raise ValueError(
-                "Endpoint must be a valid URL address starting with http:// or https://."
-            )
-
-        if priority_requirement is not None and priority_requirement < 0:
-            raise ValueError("Priority requirement must be a non-negative integer.")
+        validate_service_endpoint(endpoint)
+        validate_priority_requirement(priority_requirement)

--- a/factom_did/client/validators.py
+++ b/factom_did/client/validators.py
@@ -1,0 +1,52 @@
+import re
+
+from factom_did.client.constants import DID_METHOD_NAME
+from factom_did.client.enums import KeyType, Network
+
+
+def validate_alias(alias):
+    if not re.match("^[a-z0-9-]{1,32}$", alias):
+        raise ValueError(
+            "Alias must not be more than 32 characters long and must contain only lower-case "
+            "letters, digits and hyphens."
+        )
+
+
+def validate_did(did):
+    if not re.match(
+        "^{}:({}:|{}:)?[a-f0-9]{{64}}$".format(
+            DID_METHOD_NAME, Network.Mainnet.value, Network.Testnet.value
+        ),
+        did,
+    ):
+        raise ValueError("Controller must be a valid DID.")
+
+
+def validate_full_key_identifier(did):
+    if not re.match(
+        "^{}:({}:|{}:)?[a-f0-9]{{64}}#[a-zA-Z0-9-]{{1,32}}$".format(
+            DID_METHOD_NAME, Network.Mainnet.value, Network.Testnet.value
+        ),
+        did,
+    ):
+        raise ValueError("Controller must be a valid DID.")
+
+
+def validate_service_endpoint(endpoint):
+    if not re.match(
+        r"^(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$",
+        endpoint,
+    ):
+        raise ValueError(
+            "Endpoint must be a valid URL address starting with http:// or https://."
+        )
+
+
+def validate_priority_requirement(priority_requirement):
+    if priority_requirement is not None and priority_requirement < 0:
+        raise ValueError("Priority requirement must be a non-negative integer.")
+
+
+def validate_key_type(key_type):
+    if key_type not in (KeyType.ECDSA, KeyType.EdDSA, KeyType.RSA):
+        raise ValueError("Type must be a valid signature type.")

--- a/factom_did/resolver/validators.py
+++ b/factom_did/resolver/validators.py
@@ -1,9 +1,8 @@
-import re
-
 from jsonschema.exceptions import ValidationError
 
-from factom_did.client.constants import DID_METHOD_NAME, ENTRY_SCHEMA_V100
-from factom_did.client.enums import EntryType, Network
+from factom_did.client.constants import ENTRY_SCHEMA_V100
+from factom_did.client.enums import EntryType
+from factom_did.client.validators import validate_full_key_identifier
 from factom_did.resolver.exceptions import MalformedDIDManagementEntry
 
 
@@ -124,14 +123,8 @@ def _validate_schema_version(ext_ids, version):
 
 def _validate_key_identifier(ext_ids):
     try:
-        return (
-            re.match(
-                "^{}:({}:|{}:)?[0-9a-f]{{64}}#[a-zA-Z0-9-]+$".format(
-                    DID_METHOD_NAME, Network.Mainnet.value, Network.Testnet.value
-                ),
-                ext_ids[2].decode(),
-            )
-            is not None
-        )
-    except UnicodeDecodeError:
+        validate_full_key_identifier(ext_ids[2].decode())
+    except (UnicodeDecodeError, ValueError):
         return False
+    else:
+        return True


### PR DESCRIPTION
Moves `client` validators into a separate module and re-uses them within the `client` & `resolver` packages. Closes #24. Depends on #55.  