### PR TITLE
Fix inter-chain replay attack

### DIFF
--- a/factom_did/client/keys/abstract.py
+++ b/factom_did/client/keys/abstract.py
@@ -190,10 +190,16 @@ class AbstractDIDKey:
 
     def full_id(self, did):
         """
+        Constructs the full ID of the key.
+
+        Parameters
+        ----------
+        did: str
+
         Returns
         -------
         str
-            The full id for the key, constituting of the DID_METHOD_NAME, the DID and the key alias.
+            The full id for the key, constituting of the DID_METHOD_NAME, the network, the chain ID and the key alias.
         """
         return "{}#{}".format(did, self.alias)
 

--- a/factom_did/resolver/entry_processors.py
+++ b/factom_did/resolver/entry_processors.py
@@ -278,6 +278,8 @@ def process_did_update_entry_v100(
                     )
         if "add" in parsed_content:
             for key_data in parsed_content["add"].get("managementKey", []):
+                if not validate_management_key_id(key_data["id"], chain_id):
+                    return True, method_version, skipped_entries + 1
                 alias = _get_alias(key_data["id"])
                 # If double-addition of the same key is attempted, ignore the entire DIDUpdate entry
                 if alias in new_management_keys or alias in active_management_keys:

--- a/factom_did/resolver/entry_processors.py
+++ b/factom_did/resolver/entry_processors.py
@@ -235,8 +235,6 @@ def process_did_update_entry_v100(
 
     if method_version == DID_METHOD_SPEC_V020:
         key_id = ext_ids[2].decode()
-        if not validate_management_key_id_against_chain_id(key_id, chain_id):
-            return True, method_version, skipped_entries + 1
         signing_key = active_management_keys.get(_get_alias(key_id))
         if (not signing_key) or (
             not validate_signature(ext_ids, binary_content, signing_key)
@@ -247,6 +245,8 @@ def process_did_update_entry_v100(
 
         if "revoke" in parsed_content:
             for key in parsed_content["revoke"].get("managementKey", []):
+                if not validate_management_key_id_against_chain_id(key["id"], chain_id):
+                    return True, method_version, skipped_entries + 1
                 alias = _get_alias(key["id"])
                 # If revocation of a non-existent key or multiple revocations of the same key are attempted,
                 # ignore the entire DIDUpdate entry
@@ -356,7 +356,7 @@ def process_did_update_entry_v100(
 
 
 def process_did_deactivation_entry_v100(
-    chain_id,
+    _chain_id,
     ext_ids,
     binary_content,
     _parsed_content,
@@ -377,8 +377,8 @@ def process_did_deactivation_entry_v100(
 
     Parameters
     ----------
-    chain_id: str
-        The DIDManagement chain ID.
+    _chain_id: str
+        Unused
     ext_ids: list
         The ExtIDs of the entry, as bytes.
     binary_content: bytes
@@ -408,12 +408,8 @@ def process_did_deactivation_entry_v100(
         of skipped entries in the DIDManagement chain.
     """
     if method_version == DID_METHOD_SPEC_V020:
-        # DIDDeactivation entry must be signed by an active management key of priority 0, referenced using a full
-        # key identifier matching the current chain ID
+        # DIDDeactivation entry must be signed by an active management key of priority 0
         key_id = ext_ids[2].decode()
-        if not validate_management_key_id_against_chain_id(key_id, chain_id):
-            print("shit shit")
-            return True, method_version, skipped_entries + 1
         signing_key = active_management_keys.get(_get_alias(key_id))
         if (
             not signing_key
@@ -432,7 +428,7 @@ def process_did_deactivation_entry_v100(
 
 
 def process_did_method_version_upgrade_entry_v100(
-    chain_id,
+    _chain_id,
     ext_ids,
     binary_content,
     parsed_content,
@@ -453,8 +449,8 @@ def process_did_method_version_upgrade_entry_v100(
 
     Parameters
     ----------
-    chain_id: str
-        The DIDManagement chain ID.
+    _chain_id: str
+        Unused
     ext_ids: list
         The ExtIDs of the entry, as bytes.
     binary_content: bytes
@@ -487,8 +483,6 @@ def process_did_method_version_upgrade_entry_v100(
 
     if method_version == DID_METHOD_SPEC_V020:
         key_id = ext_ids[2].decode()
-        if not validate_management_key_id_against_chain_id(key_id, chain_id):
-            return True, method_version, skipped_entries + 1
         signing_key = active_management_keys.get(_get_alias(key_id))
         if (
             signing_key

--- a/factom_did/resolver/entry_processors.py
+++ b/factom_did/resolver/entry_processors.py
@@ -10,7 +10,7 @@ from factom_did.client.keys.management import ManagementKey
 from factom_did.client.service import Service
 from factom_did.resolver.exceptions import MalformedDIDManagementEntry
 from factom_did.resolver.validators import (
-    validate_management_key_id,
+    validate_management_key_id_against_chain_id,
     validate_signature,
 )
 
@@ -127,7 +127,7 @@ def process_did_management_entry_v100(
 
     found_key_with_priority_zero = False
     for key_data in parsed_content["managementKey"]:
-        if not validate_management_key_id(key_data["id"], chain_id):
+        if not validate_management_key_id_against_chain_id(key_data["id"], chain_id):
             raise MalformedDIDManagementEntry(
                 "Invalid key identifier '{}' for chain ID '{}'".format(
                     key_data["id"], chain_id
@@ -278,7 +278,9 @@ def process_did_update_entry_v100(
                     )
         if "add" in parsed_content:
             for key_data in parsed_content["add"].get("managementKey", []):
-                if not validate_management_key_id(key_data["id"], chain_id):
+                if not validate_management_key_id_against_chain_id(
+                    key_data["id"], chain_id
+                ):
                     return True, method_version, skipped_entries + 1
                 alias = _get_alias(key_data["id"])
                 # If double-addition of the same key is attempted, ignore the entire DIDUpdate entry

--- a/factom_did/resolver/parser.py
+++ b/factom_did/resolver/parser.py
@@ -58,7 +58,7 @@ ENTRY_PROCESSORS = {
 }
 
 
-def parse_did_chain_entries(entries):
+def parse_did_chain_entries(entries, chain_id):
     """
     Attempts to parse the entries in a DIDManagement chain.
 
@@ -68,6 +68,8 @@ def parse_did_chain_entries(entries):
         A list of entries in the DIDManagement chain as returned by the Python factom-api library, or an equivalent
         API/library. Each element of the list is a dictionary, with keys 'content', 'extids' and 'entryhash' and the
         values are bytes.
+    chain_id: str
+        The DIDManagement chain ID.
 
     Returns
     -------
@@ -131,6 +133,7 @@ def parse_did_chain_entries(entries):
                 keep_parsing, method_version, skipped_entries = ENTRY_PROCESSORS[
                     schema_version
                 ][entry_type](
+                    chain_id,
                     parsed_content,
                     active_management_keys,
                     active_did_keys,
@@ -186,6 +189,7 @@ def parse_did_chain_entries(entries):
                 keep_parsing, method_version, skipped_entries = ENTRY_PROCESSORS[
                     schema_version
                 ][entry_type](
+                    chain_id,
                     ext_ids,
                     binary_content,
                     parsed_content,

--- a/factom_did/resolver/parser.py
+++ b/factom_did/resolver/parser.py
@@ -179,7 +179,7 @@ def parse_did_chain_entries(entries, chain_id, network=Network.Mainnet):
                     or schema_version not in ENTRY_SCHEMA_VALIDATORS
                     or entry_type not in ENTRY_SCHEMA_VALIDATORS[schema_version]
                     or not ENTRY_EXT_ID_VALIDATORS[schema_version][entry_type](
-                        ext_ids, chain_id
+                        ext_ids, chain_id, network
                     )
                 ):
                     skipped_entries += 1

--- a/factom_did/resolver/parser.py
+++ b/factom_did/resolver/parser.py
@@ -4,7 +4,7 @@ from json import JSONDecodeError
 from jsonschema.exceptions import ValidationError
 
 from factom_did.client.constants import ENTRY_SCHEMA_V100
-from factom_did.client.enums import EntryType
+from factom_did.client.enums import EntryType, Network
 from factom_did.resolver.entry_processors import (
     process_did_deactivation_entry_v100,
     process_did_management_entry_v100,
@@ -58,7 +58,7 @@ ENTRY_PROCESSORS = {
 }
 
 
-def parse_did_chain_entries(entries, chain_id):
+def parse_did_chain_entries(entries, chain_id, network=Network.Mainnet):
     """
     Attempts to parse the entries in a DIDManagement chain.
 
@@ -127,6 +127,7 @@ def parse_did_chain_entries(entries, chain_id):
                 parsed_content = json.loads(binary_content.decode())
                 schema_version = ext_ids[1].decode()
                 ENTRY_EXT_ID_VALIDATORS[schema_version][entry_type](ext_ids)
+                print(parsed_content)
                 ENTRY_SCHEMA_VALIDATORS[schema_version][entry_type].validate(
                     parsed_content
                 )

--- a/factom_did/resolver/parser.py
+++ b/factom_did/resolver/parser.py
@@ -178,7 +178,9 @@ def parse_did_chain_entries(entries, chain_id, network=Network.Mainnet):
                     entry_type == EntryType.Create.value
                     or schema_version not in ENTRY_SCHEMA_VALIDATORS
                     or entry_type not in ENTRY_SCHEMA_VALIDATORS[schema_version]
-                    or not ENTRY_EXT_ID_VALIDATORS[schema_version][entry_type](ext_ids)
+                    or not ENTRY_EXT_ID_VALIDATORS[schema_version][entry_type](
+                        ext_ids, chain_id
+                    )
                 ):
                     skipped_entries += 1
                     continue

--- a/factom_did/resolver/parser.py
+++ b/factom_did/resolver/parser.py
@@ -67,9 +67,11 @@ def parse_did_chain_entries(entries, chain_id, network=Network.Mainnet):
     entries: list of dict
         A list of entries in the DIDManagement chain as returned by the Python factom-api library, or an equivalent
         API/library. Each element of the list is a dictionary, with keys 'content', 'extids' and 'entryhash' and the
-        values are bytes.
+        values are bytes
     chain_id: str
-        The DIDManagement chain ID.
+        The DIDManagement chain ID
+    network: Network
+        The Factom network on which the DID is recorded
 
     Returns
     -------
@@ -127,7 +129,6 @@ def parse_did_chain_entries(entries, chain_id, network=Network.Mainnet):
                 parsed_content = json.loads(binary_content.decode())
                 schema_version = ext_ids[1].decode()
                 ENTRY_EXT_ID_VALIDATORS[schema_version][entry_type](ext_ids)
-                print(parsed_content)
                 ENTRY_SCHEMA_VALIDATORS[schema_version][entry_type].validate(
                     parsed_content
                 )
@@ -140,6 +141,7 @@ def parse_did_chain_entries(entries, chain_id, network=Network.Mainnet):
                     active_did_keys,
                     active_services,
                     skipped_entries,
+                    network,
                 )
                 all_keys.update(
                     active_management_keys.values(), active_did_keys.values()
@@ -200,6 +202,7 @@ def parse_did_chain_entries(entries, chain_id, network=Network.Mainnet):
                     active_services,
                     skipped_entries,
                     all_keys,
+                    network,
                 )
                 all_keys.update(
                     active_management_keys.values(), active_did_keys.values()

--- a/factom_did/resolver/schemas/1.0.0/did_key.json
+++ b/factom_did/resolver/schemas/1.0.0/did_key.json
@@ -3,11 +3,17 @@
   "title": "DID key schema",
   "type": "object",
   "properties": {
-    "id": {"type": "string"},
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]{1,32}$|^#[a-z0-9-]{1,32}$|^did:factom:(mainnet:|testnet:)?[0-9a-f]{64}#[a-z0-9-]{1,32}$"
+    },
     "type": {
       "enum": ["Ed25519VerificationKey", "ECDSASecp256k1VerificationKey", "RSAVerificationKey"]
     },
-    "controller": {"type": "string"},
+    "controller": {
+      "type": "string",
+      "pattern": "^did:factom:(mainnet:|testnet:)?[0-9a-f]{64}$"
+    },
     "publicKeyBase58": {"type": "string"},
     "publicKeyPem": {"type": "string"},
     "purpose": {

--- a/factom_did/resolver/schemas/1.0.0/management_key.json
+++ b/factom_did/resolver/schemas/1.0.0/management_key.json
@@ -3,11 +3,17 @@
   "title": "Management key schema",
   "type": "object",
   "properties": {
-    "id": {"type": "string"},
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]{1,32}$|^#[a-z0-9-]{1,32}$|^did:factom:(mainnet:|testnet:)?[0-9a-f]{64}#[a-z0-9-]{1,32}$"
+    },
     "type": {
       "enum": ["Ed25519VerificationKey", "ECDSASecp256k1VerificationKey", "RSAVerificationKey"]
     },
-    "controller": {"type": "string"},
+    "controller": {
+      "type": "string",
+      "pattern": "^did:factom:(mainnet:|testnet:)?[0-9a-f]{64}$"
+    },
     "publicKeyBase58": {"type": "string"},
     "publicKeyPem": {"type": "string"},
     "priority": {"type": "integer", "minimum": 0},

--- a/factom_did/resolver/schemas/1.0.0/service.json
+++ b/factom_did/resolver/schemas/1.0.0/service.json
@@ -3,7 +3,10 @@
   "title": "Service schema",
   "type": "object",
   "properties": {
-    "id": {"type": "string"},
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]{1,32}$|^#[a-z0-9-]{1,32}$|^did:factom:(mainnet:|testnet:)?[0-9a-f]{64}#[a-z0-9-]{1,32}$"
+    },
     "type": {"type": "string"},
     "serviceEndpoint": {"type": "string", "format": "uri"},
     "priorityRequirement": {"type": "integer", "minimum":  0}

--- a/factom_did/resolver/validators.py
+++ b/factom_did/resolver/validators.py
@@ -145,8 +145,6 @@ def validate_management_key_id_against_chain_id(key_id, chain_id):
     -------
     bool
     """
-    # Due to prior validation of the entries, the key_id passed to this function is guaranteed to be a well-formed
-    # full key identifier
     key_id_chain = key_id.split(":")[-1].split("#")[0]
     return key_id_chain == chain_id
 

--- a/factom_did/resolver/validators.py
+++ b/factom_did/resolver/validators.py
@@ -130,7 +130,7 @@ def validate_signature(ext_ids, content, signing_key):
     return signing_key.verify(hashlib.sha256(signed_data).digest(), ext_ids[3])
 
 
-def validate_management_key_id(key_id, chain_id):
+def validate_management_key_id_against_chain_id(key_id, chain_id):
     """
     Checks if the chain in the key_id matches the value supplied in chain_id.
 

--- a/factom_did/resolver/validators.py
+++ b/factom_did/resolver/validators.py
@@ -39,7 +39,7 @@ def validate_did_management_ext_ids_v100(ext_ids):
         )
 
 
-def validate_did_update_ext_ids_v100(ext_ids):
+def validate_did_update_ext_ids_v100(ext_ids, chain_id):
     """
     Validates the ExtIDs of a DIDUpdate entry.
 
@@ -47,6 +47,8 @@ def validate_did_update_ext_ids_v100(ext_ids):
     ----------
     ext_ids: list of bytes
         The ExtIDs of the entry
+    chain_id: str
+        The chain ID where the DIDUpdate is recorded
 
     Returns
     -------
@@ -58,10 +60,11 @@ def validate_did_update_ext_ids_v100(ext_ids):
         and _validate_entry_type(ext_ids, EntryType.Update)
         and _validate_schema_version(ext_ids, ENTRY_SCHEMA_V100)
         and _validate_full_key_identifier(ext_ids)
+        and validate_management_key_id_against_chain_id(ext_ids[2], chain_id)
     )
 
 
-def validate_did_method_version_upgrade_ext_ids_v100(ext_ids):
+def validate_did_method_version_upgrade_ext_ids_v100(ext_ids, chain_id):
     """
     Validates the ExtIDs of a DIDMethodVersionUpgrade entry.
 
@@ -69,6 +72,8 @@ def validate_did_method_version_upgrade_ext_ids_v100(ext_ids):
     ----------
     ext_ids: list of bytes
         The ExtIDs of the entry
+    chain_id: str
+        The chain ID where the DIDUpdate is recorded
 
     Returns
     -------
@@ -80,10 +85,11 @@ def validate_did_method_version_upgrade_ext_ids_v100(ext_ids):
         and _validate_entry_type(ext_ids, EntryType.VersionUpgrade)
         and _validate_schema_version(ext_ids, ENTRY_SCHEMA_V100)
         and _validate_full_key_identifier(ext_ids)
+        and validate_management_key_id_against_chain_id(ext_ids[2], chain_id)
     )
 
 
-def validate_did_deactivation_ext_ids_v100(ext_ids):
+def validate_did_deactivation_ext_ids_v100(ext_ids, chain_id):
     """
     Validates the ExtIDs of a DIDDeactivation entry.
 
@@ -91,6 +97,8 @@ def validate_did_deactivation_ext_ids_v100(ext_ids):
     ----------
     ext_ids: list of bytes
         The ExtIDs of the entry
+    chain_id: str
+        The chain ID where the DIDUpdate is recorded
 
     Returns
     -------
@@ -102,6 +110,7 @@ def validate_did_deactivation_ext_ids_v100(ext_ids):
         and _validate_entry_type(ext_ids, EntryType.Deactivation)
         and _validate_schema_version(ext_ids, ENTRY_SCHEMA_V100)
         and _validate_full_key_identifier(ext_ids)
+        and validate_management_key_id_against_chain_id(ext_ids[2], chain_id)
     )
 
 
@@ -136,20 +145,26 @@ def validate_management_key_id_against_chain_id(key_id, chain_id):
 
     Parameters
     ----------
-    key_id: str
-        The well-formed partial or full key identifier
+    key_id: bytes or str
+        The partial or full key identifier
     chain_id: str
         The chain ID
+
+    Raises
+    ------
+    UnicodeDecodeError
+        If the key_id cannot be decoded to a Unicode string
 
     Returns
     -------
     bool
     """
     # If the identifier is a full key id, extract the chain and compare it to the provided value
+    if type(key_id) is bytes:
+        key_id = key_id.decode()
     if ":" in key_id:
         key_id_chain = key_id.split(":")[-1].split("#")[0]
         return key_id_chain == chain_id
-    # Otherwise, just return True
     else:
         return True
 

--- a/factom_did/resolver/validators.py
+++ b/factom_did/resolver/validators.py
@@ -57,7 +57,7 @@ def validate_did_update_ext_ids_v100(ext_ids):
         _validate_ext_ids_length(ext_ids, 4)
         and _validate_entry_type(ext_ids, EntryType.Update)
         and _validate_schema_version(ext_ids, ENTRY_SCHEMA_V100)
-        and _validate_key_identifier(ext_ids)
+        and _validate_full_key_identifier(ext_ids)
     )
 
 
@@ -79,7 +79,7 @@ def validate_did_method_version_upgrade_ext_ids_v100(ext_ids):
         _validate_ext_ids_length(ext_ids, 4)
         and _validate_entry_type(ext_ids, EntryType.VersionUpgrade)
         and _validate_schema_version(ext_ids, ENTRY_SCHEMA_V100)
-        and _validate_key_identifier(ext_ids)
+        and _validate_full_key_identifier(ext_ids)
     )
 
 
@@ -101,7 +101,7 @@ def validate_did_deactivation_ext_ids_v100(ext_ids):
         _validate_ext_ids_length(ext_ids, 4)
         and _validate_entry_type(ext_ids, EntryType.Deactivation)
         and _validate_schema_version(ext_ids, ENTRY_SCHEMA_V100)
-        and _validate_key_identifier(ext_ids)
+        and _validate_full_key_identifier(ext_ids)
     )
 
 
@@ -137,7 +137,7 @@ def validate_management_key_id_against_chain_id(key_id, chain_id):
     Parameters
     ----------
     key_id: str
-        The well-formed full key identifier
+        The well-formed partial or full key identifier
     chain_id: str
         The chain ID
 
@@ -145,8 +145,13 @@ def validate_management_key_id_against_chain_id(key_id, chain_id):
     -------
     bool
     """
-    key_id_chain = key_id.split(":")[-1].split("#")[0]
-    return key_id_chain == chain_id
+    # If the identifier is a full key id, extract the chain and compare it to the provided value
+    if ":" in key_id:
+        key_id_chain = key_id.split(":")[-1].split("#")[0]
+        return key_id_chain == chain_id
+    # Otherwise, just return True
+    else:
+        return True
 
 
 def _validate_ext_ids_length(ext_ids, min_length):
@@ -167,7 +172,7 @@ def _validate_schema_version(ext_ids, version):
         return False
 
 
-def _validate_key_identifier(ext_ids):
+def _validate_full_key_identifier(ext_ids):
     try:
         validate_full_key_identifier(ext_ids[2].decode())
     except (UnicodeDecodeError, ValueError):

--- a/tests/resolver/test_parser.py
+++ b/tests/resolver/test_parser.py
@@ -587,9 +587,8 @@ class TestDIDDeactivationEntry:
             [entry_1, entry_2], chain_id
         )
 
-        assert False
-        # assert len(management_keys) == 1
-        # assert skipped_entries == 1
+        assert len(management_keys) == 1
+        assert skipped_entries == 1
 
 
 class TestDIDVersionUpgradeEntry:
@@ -1209,6 +1208,27 @@ class TestDIDUpdateEntry:
 
         assert skipped_entries == 1
         assert len(management_keys) == 1
+
+    def test_with_revocation_of_management_key_from_another_chain(
+        self, did, did_2, man_key_1, man_key_5, management_entry, update_entry, chain_id
+    ):
+        entry_1 = management_entry(
+            {
+                "managementKey": [
+                    man_key_1.to_entry_dict(did),
+                    man_key_5.to_entry_dict(did),
+                ]
+            }
+        )
+        # We try to revoke the same key added above, but with its chain referencing the chain of did_2
+        content = {"revoke": {"managementKey": [{"id": man_key_5.full_id(did_2)}]}}
+        entry_2 = update_entry(did, man_key_1, content)
+        management_keys, _, _, skipped_entries = parse_did_chain_entries(
+            [entry_1, entry_2], chain_id
+        )
+
+        assert skipped_entries == 1
+        assert len(management_keys) == 2
 
     def test_with_signature_from_management_key_from_another_chain(
         self, did, did_2, man_key_1, did_key_1, management_entry, update_entry, chain_id

--- a/tests/resolver/test_parser.py
+++ b/tests/resolver/test_parser.py
@@ -390,7 +390,7 @@ class TestDIDManagementEntry:
             "Malformed DIDManagement entry: Invalid key identifier"
         )
 
-    def test_with_invalid_key_identifiers(
+    def test_with_invalid_key_identifier(
         self, did, man_key_1, management_entry, chain_id
     ):
         entry_1 = management_entry(
@@ -411,7 +411,7 @@ class TestDIDManagementEntry:
         with pytest.raises(InvalidDIDChain):
             parse_did_chain_entries([entry_1], chain_id)
 
-    def test_with_partial_key_identifiers(
+    def test_with_partial_key_identifier(
         self, did, man_key_1, management_entry, chain_id
     ):
         entry_1 = management_entry(
@@ -434,8 +434,8 @@ class TestDIDManagementEntry:
             [entry_1], chain_id
         )
 
-        assert len(management_keys) == 0
-        assert skipped_entries == 1
+        assert len(management_keys) == 1
+        assert skipped_entries == 0
 
     def test_valid_did_management_entry(
         self,

--- a/tests/resolver/test_parser.py
+++ b/tests/resolver/test_parser.py
@@ -1070,3 +1070,16 @@ class TestDIDUpdateEntry:
         assert skipped_entries == 1
         assert len(management_keys) == 1
         assert len(did_keys) == 0
+
+    def test_with_adding_management_key_from_another_chain(
+        self, did, did_2, man_key_1, man_key_5, management_entry, update_entry, chain_id
+    ):
+        entry_1 = management_entry({"managementKey": [man_key_1.to_entry_dict(did)]})
+        content = {"add": {"managementKey": [man_key_5.to_entry_dict(did_2)]}}
+        entry_2 = update_entry(did, man_key_1, content)
+        management_keys, _, _, skipped_entries = parse_did_chain_entries(
+            [entry_1, entry_2], chain_id
+        )
+
+        assert skipped_entries == 1
+        assert len(management_keys) == 1

--- a/tests/resolver/test_parser.py
+++ b/tests/resolver/test_parser.py
@@ -390,6 +390,53 @@ class TestDIDManagementEntry:
             "Malformed DIDManagement entry: Invalid key identifier"
         )
 
+    def test_with_invalid_key_identifiers(
+        self, did, man_key_1, management_entry, chain_id
+    ):
+        entry_1 = management_entry(
+            {
+                "managementKey": [
+                    {
+                        "id": "did:fatcom:{}#man-key-1".format(chain_id),
+                        "type": "ECDSASecp256k1VerificationKey",
+                        "priority": 0,
+                        "controller": did,
+                        "publicKeyBase58": man_key_1.underlying.get_public_key_on_chain_repr()[
+                            1
+                        ],
+                    }
+                ]
+            }
+        )
+        with pytest.raises(InvalidDIDChain):
+            parse_did_chain_entries([entry_1], chain_id)
+
+    def test_with_partial_key_identifiers(
+        self, did, man_key_1, management_entry, chain_id
+    ):
+        entry_1 = management_entry(
+            {
+                "managementKey": [
+                    {
+                        "id": "man-key-1",
+                        "type": "ECDSASecp256k1VerificationKey",
+                        "priority": 0,
+                        "controller": did,
+                        "publicKeyBase58": man_key_1.underlying.get_public_key_on_chain_repr()[
+                            1
+                        ],
+                    }
+                ]
+            }
+        )
+
+        management_keys, _, _, skipped_entries = parse_did_chain_entries(
+            [entry_1], chain_id
+        )
+
+        assert len(management_keys) == 0
+        assert skipped_entries == 1
+
     def test_valid_did_management_entry(
         self,
         did,

--- a/tests/resolver/test_validators.py
+++ b/tests/resolver/test_validators.py
@@ -135,35 +135,41 @@ class TestDIDUpdateEntryValidation:
     VALIDATOR = get_schema_validator("did_update_entry.json")
 
     def test_insufficient_extids(self):
+        chain_id = secrets.token_hex(32)
         assert (
             validate_did_update_ext_ids_v100(
                 [
                     b"DIDUpdate",
                     b"1.0.0",
-                    "{}:{}#my-key".format(
-                        DID_METHOD_NAME, secrets.token_hex(32)
-                    ).encode("utf-8"),
-                ]
+                    "{}:{}#my-key".format(DID_METHOD_NAME, chain_id).encode("utf-8"),
+                ],
+                chain_id,
             )
             is False
         )
 
     def test_malformed_extids(self):
-        key_id = "{}:{}#{}".format(
-            DID_METHOD_NAME, secrets.token_hex(32), "my-man-key-1"
-        )
+        chain_id = secrets.token_hex(32)
+        key_id = "{}:{}#{}".format(DID_METHOD_NAME, chain_id, "my-man-key-1")
+
         assert (
-            validate_did_update_ext_ids_v100([b"DIdUpdate", b"1.0.0", key_id, b"af01"])
+            validate_did_update_ext_ids_v100(
+                [b"DIdUpdate", b"1.0.0", key_id.encode("utf-8"), b"af01"], chain_id
+            )
             is False
         )
 
         assert (
-            validate_did_update_ext_ids_v100([b"DIDUpdate", b"1.0.0", b"\xbb", b"af01"])
+            validate_did_update_ext_ids_v100(
+                [b"DIDUpdate", b"1.0.0", b"\xbb", b"af01"], chain_id
+            )
             is False
         )
 
         assert (
-            validate_did_update_ext_ids_v100([b"DIDUpdate", b"1.0.", key_id, b"af01"])
+            validate_did_update_ext_ids_v100(
+                [b"DIDUpdate", b"1.0.", key_id.encode("utf-8"), b"af01"], chain_id
+            )
             is False
         )
 
@@ -174,13 +180,15 @@ class TestDIDUpdateEntryValidation:
                     b"1.0.0",
                     key_id[: key_id.find("#")].encode("utf-8"),
                     b"af01",
-                ]
+                ],
+                chain_id,
             )
             is False
         )
 
     def test_invalid_entry(self):
-        did = "{}:{}".format(DID_METHOD_NAME, secrets.token_hex(32))
+        chain_id = secrets.token_hex(32)
+        did = "{}:{}".format(DID_METHOD_NAME, chain_id)
 
         # Entry with invalid property names
         with pytest.raises(ValidationError):
@@ -237,11 +245,12 @@ class TestDIDUpdateEntryValidation:
             )
 
     def test_valid_entry(self):
-        did = "{}:{}".format(DID_METHOD_NAME, secrets.token_hex(32))
+        chain_id = secrets.token_hex(32)
+        did = "{}:{}".format(DID_METHOD_NAME, chain_id)
         key_id = "{}#{}".format(did, "my-man-key-1")
 
         validate_did_update_ext_ids_v100(
-            [b"DIDUpdate", b"1.0.0", key_id.encode("utf-8"), b"affe"]
+            [b"DIDUpdate", b"1.0.0", key_id.encode("utf-8"), b"affe"], chain_id
         )
 
         # Entry with only additions should be valid
@@ -338,33 +347,39 @@ class TestDIDMethodVersionUpgradeEntryValidation:
     VALIDATOR = get_schema_validator("did_method_version_upgrade_entry.json")
 
     def test_insufficient_extids(self):
+        chain_id = secrets.token_hex(32)
         assert (
             validate_did_method_version_upgrade_ext_ids_v100(
                 [
                     b"DIDMethodVersionUpgrade",
                     b"1.0.0",
-                    "{}:{}#my-key".format(
-                        DID_METHOD_NAME, secrets.token_hex(32)
-                    ).encode("utf-8"),
-                ]
+                    "{}:{}#my-key".format(DID_METHOD_NAME, chain_id).encode("utf-8"),
+                ],
+                chain_id,
             )
             is False
         )
 
     def test_malformed_extids(self):
-        key_id = "{}:{}#{}".format(
-            DID_METHOD_NAME, secrets.token_hex(32), "my-man-key-1"
-        )
+        chain_id = secrets.token_hex(32)
+        key_id = "{}:{}#{}".format(DID_METHOD_NAME, chain_id, "my-man-key-1")
         assert (
             validate_did_method_version_upgrade_ext_ids_v100(
-                [b"DIDMethodVersionsUpgrade", b"1.0.0", key_id.encode("utf-8"), b"af01"]
+                [
+                    b"DIDMethodVersionsUpgrade",
+                    b"1.0.0",
+                    key_id.encode("utf-8"),
+                    b"af01",
+                ],
+                chain_id,
             )
             is False
         )
 
         assert (
             validate_did_method_version_upgrade_ext_ids_v100(
-                [b"DIDMethodVersionUpgrade", b"1.0.", key_id.encode("utf-8"), b"af01"]
+                [b"DIDMethodVersionUpgrade", b"1.0.", key_id.encode("utf-8"), b"af01"],
+                chain_id,
             )
             is False
         )
@@ -376,7 +391,8 @@ class TestDIDMethodVersionUpgradeEntryValidation:
                     b"1.0.0",
                     key_id[: key_id.find("#")].encode("utf-8"),
                     b"0xaf01",
-                ]
+                ],
+                chain_id,
             )
             is False
         )
@@ -399,12 +415,12 @@ class TestDIDMethodVersionUpgradeEntryValidation:
             self.VALIDATOR.validate({"didMethodVersion": "1.0.2", "additional": 1})
 
     def test_valid_entry(self):
-        key_id = "{}:{}#{}".format(
-            DID_METHOD_NAME, secrets.token_hex(32), "my-man-key-1"
-        )
+        chain_id = secrets.token_hex(32)
+        key_id = "{}:{}#{}".format(DID_METHOD_NAME, chain_id, "my-man-key-1")
         assert (
             validate_did_method_version_upgrade_ext_ids_v100(
-                [b"DIDMethodVersionUpgrade", b"1.0.0", key_id.encode("utf-8"), b"af01"]
+                [b"DIDMethodVersionUpgrade", b"1.0.0", key_id.encode("utf-8"), b"af01"],
+                chain_id,
             )
             is True
         )
@@ -413,33 +429,32 @@ class TestDIDMethodVersionUpgradeEntryValidation:
 
 class TestDIDDeactivationEntryValidation:
     def test_insufficient_extids(self):
+        chain_id = secrets.token_hex(32)
         assert (
             validate_did_deactivation_ext_ids_v100(
                 [
                     b"DIDDeactivation",
                     b"1.0.0",
-                    "{}:{}#my-key".format(
-                        DID_METHOD_NAME, secrets.token_hex(32)
-                    ).encode("utf-8"),
-                ]
+                    "{}:{}#my-key".format(DID_METHOD_NAME, chain_id).encode("utf-8"),
+                ],
+                chain_id,
             )
             is False
         )
 
     def test_malformed_extids(self):
-        key_id = "{}:{}#{}".format(
-            DID_METHOD_NAME, secrets.token_hex(32), "my-man-key-1"
-        )
+        chain_id = secrets.token_hex(32)
+        key_id = "{}:{}#{}".format(DID_METHOD_NAME, chain_id, "my-man-key-1")
         assert (
             validate_did_deactivation_ext_ids_v100(
-                [b"DIDDeactivated", b"1.0.0", key_id.encode("utf-8"), b"af01"]
+                [b"DIDDeactivated", b"1.0.0", key_id.encode("utf-8"), b"af01"], chain_id
             )
             is False
         )
 
         assert (
             validate_did_deactivation_ext_ids_v100(
-                [b"DIDDeactivation", b"1.0.", key_id.encode("utf-8"), b"af01"]
+                [b"DIDDeactivation", b"1.0.", key_id.encode("utf-8"), b"af01"], chain_id
             )
             is False
         )
@@ -451,7 +466,8 @@ class TestDIDDeactivationEntryValidation:
                     b"1.0.0",
                     key_id[: key_id.find("#")].encode("utf-8"),
                     b"af01",
-                ]
+                ],
+                chain_id,
             )
             is False
         )
@@ -461,12 +477,12 @@ class TestDIDDeactivationEntryValidation:
             EmptyEntryContentValidator.validate({"some": "data"})
 
     def test_valid_entry(self):
-        key_id = "{}:{}#{}".format(
-            DID_METHOD_NAME, secrets.token_hex(32), "my-man-key-1"
-        )
+        chain_id = secrets.token_hex(32)
+        key_id = "{}:{}#{}".format(DID_METHOD_NAME, chain_id, "my-man-key-1")
         assert (
             validate_did_deactivation_ext_ids_v100(
-                [b"DIDDeactivation", b"1.0.0", key_id.encode("utf-8"), b"af01"]
+                [b"DIDDeactivation", b"1.0.0", key_id.encode("utf-8"), b"af01"],
+                chain_id,
             )
             is True
         )


### PR DESCRIPTION
Closes #53, closes #47, closes #58.

- [x] add unit tests for partial key identifiers
- [x] add validation of network used in key identifiers (e.g. cannot have 'testnet' in key identifier for mainnet DID resolution and vice versa)